### PR TITLE
ci: run verify pipeline at concurrency 1 to stop runner OOM kills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: bun run check-types:decimal-e2e
 
       - name: Verify
-        run: bun run turbo run lint check-types test build --concurrency=2
+        run: bun run turbo run lint check-types test build --concurrency=1
 
       - name: Verify browser resource budgets in Chrome
         run: bun run --cwd apps/web test:resource-budgets:chrome


### PR DESCRIPTION
Two of today's main verify runs were OOM-killed (exit 137) mid-suite, which keeps skipping the deploy job — production has not received #450/#452 yet. Serializing the turbo pipeline bounds peak memory; verify wall-clock grows a few minutes but completes.

After this merges, main's next push (or a rerun of the failed run) should go green end-to-end and finally trigger the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)