### PR TITLE
fix(api): stop stale clickhouse mock allowlists leaking across test files

### DIFF
--- a/apps/api/src/__tests__/session-list-date-range.test.ts
+++ b/apps/api/src/__tests__/session-list-date-range.test.ts
@@ -4,6 +4,7 @@ import {
 	addOptionalStringEqFilter,
 	buildDateFilter,
 	buildInclusiveDateRangeFilter,
+	getSafeClickHouseTable,
 } from "../clickhouse.js";
 
 /**
@@ -16,21 +17,9 @@ import {
 
 const queryCalls: ClickHouseStatement[] = [];
 
-const allowedClickHouseTables = new Set([
-	"rudel.claude_sessions",
-	"rudel.codex_sessions",
-	"rudel.session_analytics",
-	"rudel.usage_events",
-	"rudel.wrapped_user_archetype_snapshots_v1",
-]);
-
-function getSafeTestClickHouseTable(table: string): string {
-	if (!allowedClickHouseTables.has(table)) {
-		throw new Error(`Unsupported ClickHouse table: ${table}`);
-	}
-	return table;
-}
-
+// Bun's mock.module is process-global and leaks across test files, so this mock
+// must never carry its own copy of the table allowlist — a stale copy poisons
+// whichever test file runs after this one. Delegate to the real implementation.
 mock.module("../clickhouse.js", () => ({
 	addOptionalStringEqFilter,
 	buildDateFilter,
@@ -38,7 +27,7 @@ mock.module("../clickhouse.js", () => ({
 	getClickhouse: () => ({
 		query: () => Promise.resolve([]),
 	}),
-	getSafeClickHouseTable: getSafeTestClickHouseTable,
+	getSafeClickHouseTable,
 	queryClickhouse: (statement: ClickHouseStatement) => {
 		queryCalls.push(statement);
 		return Promise.resolve([]);
@@ -102,9 +91,9 @@ describe("session list date range", () => {
 
 	test("preserves the production ClickHouse table allowlist in the module mock", () => {
 		expect(() =>
-			getSafeTestClickHouseTable("rudel.session_analytics"),
+			getSafeClickHouseTable("rudel.session_analytics"),
 		).not.toThrow();
-		expect(() => getSafeTestClickHouseTable("rudel.unknown_table")).toThrow(
+		expect(() => getSafeClickHouseTable("rudel.unknown_table")).toThrow(
 			"Unsupported ClickHouse table: rudel.unknown_table",
 		);
 	});

--- a/apps/api/src/services/wrapped.service.test.ts
+++ b/apps/api/src/services/wrapped.service.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+	addOptionalStringEqFilter,
+	addOptionalStringInFilter,
+	buildAbsoluteDateFilter,
+	buildDateFilter,
+	getSafeClickHouseTable,
+} from "../clickhouse.js";
 
 interface QueryClickhouseInput {
 	query: string;
@@ -44,69 +51,10 @@ const queryClickhouse = mock((input: QueryClickhouseInput) => {
 	throw new Error(`Unexpected ClickHouse query: ${input.query.slice(0, 120)}`);
 });
 
-const allowedClickHouseTables = new Set([
-	"rudel.claude_sessions",
-	"rudel.codex_sessions",
-	"rudel.session_analytics",
-	"rudel.skill_receipts",
-	"rudel.skill_uses",
-	"rudel.skill_version_contents",
-	"rudel.usage_events",
-]);
-
-function getSafeClickHouseTable(table: string): string {
-	if (!allowedClickHouseTables.has(table)) {
-		throw new Error(`Unsupported ClickHouse table: ${table}`);
-	}
-
-	return table;
-}
-
-function addOptionalStringEqFilter(
-	where: string[],
-	query_params: Record<string, unknown>,
-	column: string,
-	paramName: string,
-	value?: string,
-): void {
-	if (!value) {
-		return;
-	}
-
-	where.push(`${column} = {${paramName}:String}`);
-	query_params[paramName] = value;
-}
-
-function addOptionalStringInFilter(
-	where: string[],
-	query_params: Record<string, unknown>,
-	column: string,
-	paramBase: string,
-	values?: string[],
-): void {
-	if (!values || values.length === 0) {
-		return;
-	}
-
-	const placeholders = values.map((value, index) => {
-		const paramName = `${paramBase}_${index}`;
-		query_params[paramName] = value;
-		return `{${paramName}:String}`;
-	});
-	where.push(`${column} IN (${placeholders.join(", ")})`);
-}
-
-function buildDateFilter(paramName: string, column = "session_date"): string {
-	return `${column} >= now64(3) - toIntervalDay({${paramName}:UInt32}) AND ${column} <= now64(3)`;
-}
-
-function buildAbsoluteDateFilter(
-	startParamName: string,
-	endParamName: string,
-	column = "session_date",
-): string {
-	return `toDate(${column}) >= toDate({${startParamName}:String}) AND toDate(${column}) <= toDate({${endParamName}:String})`;
-}
+// Bun's mock.module is process-global and leaks across test files, so this mock
+// must never carry its own copies of the table allowlist or filter helpers — a
+// stale copy poisons whichever test file runs after this one. Delegate to the
+// real implementations and stub only the I/O.
 
 mock.module("../clickhouse.js", () => ({
 	addOptionalStringEqFilter,


### PR DESCRIPTION
## Problem
PR #458's `verify` job failed with `Unsupported ClickHouse table: rudel.skill_uses` in `skill-extraction-ingest.service.test.ts` — a test that passes in isolation.

Root cause: `bun:test`'s `mock.module` is **process-global and persists across test files**. Two test files mocked `../clickhouse.js` with their own **stale copies of the table allowlist** (missing the `skill_*` tables added in #455):
- `__tests__/session-list-date-range.test.ts`
- `services/wrapped.service.test.ts`

Whichever test file runs after them inherits the poisoned module. File-discovery order differs between GitHub-hosted and Blacksmith runners, so the landmine only detonated after the runner migration (cold turbo cache forcing full execution did the rest).

## Fix
The mocks no longer carry copies of pure logic — they delegate `getSafeClickHouseTable` and the filter helpers to the real module and stub **only the I/O** (`queryClickhouse`/`getClickhouse`). The allowlist can never drift again; the existing drift-guard test now asserts against the real function.

## Verification
- Repro before fix: `bun test session-list-date-range.test.ts skill-extraction-ingest.service.test.ts` (this order) fails with the exact CI error
- After fix: same pair passes; full `apps/api` suite: **391 pass / 0 fail**
- Merge this first, then re-run #458's CI — it should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/rudel/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790186023&installation_model_id=433970&pr_number=459&repository=opalinehq%2Frudel&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Frudel%2Fpull%2F459&signature=df67a70dbaa72171a115d6ca4e2857e5317162f90334b351a248004a277e3c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->