### PR TITLE
ci: disable public production deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,8 +294,9 @@ jobs:
             exit 1
           fi
 
+  # Production deploys are owned by the private opalinehq/athena repository.
   deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: false
     needs: [verify, integration]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- hard-disable the public repository's production deploy job
- document the private Athena repository as deploy-of-record

## Test plan
- [x] `bun run verify`
- [ ] GitHub verify and integration jobs pass
- [ ] merged main run records deploy as skipped

🤖 Generated with Codex

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/rudel/pr/460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790190019&installation_model_id=433970&pr_number=460&repository=opalinehq%2Frudel&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Frudel%2Fpull%2F460&signature=9e18e8a4d96cb5da2e68b71a1f37e6449de1c0009ba62759846263ee7bbee620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->