### PR TITLE
fix: drop ./ prefix from bin paths for npm 11.12 publish validation

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,7 +10,7 @@
 	"homepage": "https://app.rudel.ai",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/opalinehq/cli.git",
+		"url": "git+https://github.com/opalinehq/cli.git",
 		"directory": "apps/cli"
 	},
 	"bugs": {
@@ -26,7 +26,7 @@
 	],
 	"author": "Opaline",
 	"bin": {
-		"opaline": "./dist/cli.js"
+		"opaline": "dist/cli.js"
 	},
 	"exports": {
 		"./run": "./dist/run-cli.js"

--- a/packages/rudel-alias/package.json
+++ b/packages/rudel-alias/package.json
@@ -9,7 +9,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/opalinehq/cli.git",
+		"url": "git+https://github.com/opalinehq/cli.git",
 		"directory": "packages/rudel-alias"
 	},
 	"bugs": {
@@ -24,7 +24,7 @@
 	],
 	"author": "Opaline",
 	"bin": {
-		"rudel": "./bin/rudel.js"
+		"rudel": "bin/rudel.js"
 	},
 	"files": [
 		"bin",


### PR DESCRIPTION
npm 11.12's publish-time auto-fix strips `./`-prefixed `bin` targets (`"bin[opaline]" script name dist/cli.js was invalid and removed`), which would publish **a package with no executable**. Caught during the first manual publish attempt — nothing was published.

- `@opalinehq/cli`: `./dist/cli.js` → `dist/cli.js`
- `rudel` alias: `./bin/rudel.js` → `bin/rudel.js`
- `repository.url` normalized to `git+https` (silences the same fixer)

Verified with `npm publish --dry-run`: no auto-corrections remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/rudel/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790226548&installation_model_id=433970&pr_number=462&repository=opalinehq%2Frudel&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Frudel%2Fpull%2F462&signature=78791bf99b15522cfe1014b8193e2ce38744e4d623eebfb42ba947da8f306ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->