### PR TITLE
fix(ci): stabilize Windows opener and restore smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,19 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: bun test ./apps/cli/src/__tests__/browser-opener.windows.integration.ts
+
+  cli-smoke-required:
+    if: always()
+    needs:
+      - cli-smoke
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Require successful CLI smoke tests when applicable
+        env:
+          CLI_SMOKE_RESULT: ${{ needs.cli-smoke.result }}
+        run: |
+          if [[ "${CLI_SMOKE_RESULT}" != "success" && "${CLI_SMOKE_RESULT}" != "skipped" ]]; then
+            echo "CLI smoke tests did not succeed: ${CLI_SMOKE_RESULT}"
+            exit 1
+          fi

--- a/apps/cli/src/__tests__/browser-opener.windows.integration.ts
+++ b/apps/cli/src/__tests__/browser-opener.windows.integration.ts
@@ -4,18 +4,15 @@ import { parseSafeBrowserUrl } from "../contracts/index.js";
 import { openUrl } from "../lib/browser-opener.js";
 
 const BROWSER_REQUEST_TIMEOUT_MS = 30_000;
+const BROWSER_LAUNCH_ATTEMPTS = 2;
 
-function waitWithTimeout<T>(
-	promise: Promise<T>,
+function waitForBrowserRequest(
+	promise: Promise<URL>,
 	timeoutMs: number,
-): Promise<T> {
-	return new Promise<T>((resolve, reject) => {
+): Promise<URL | undefined> {
+	return new Promise<URL | undefined>((resolve, reject) => {
 		const timeout = setTimeout(() => {
-			reject(
-				new Error(
-					`Default browser did not request the verification URL within ${timeoutMs}ms`,
-				),
-			);
+			resolve(undefined);
 		}, timeoutMs);
 
 		promise.then(
@@ -29,6 +26,26 @@ function waitWithTimeout<T>(
 			},
 		);
 	});
+}
+
+async function openBrowserUntilRequested(
+	verificationUrl: string,
+	request: Promise<URL>,
+): Promise<URL> {
+	for (let attempt = 0; attempt < BROWSER_LAUNCH_ATTEMPTS; attempt += 1) {
+		openUrl(verificationUrl);
+		const requestedUrl = await waitForBrowserRequest(
+			request,
+			BROWSER_REQUEST_TIMEOUT_MS,
+		);
+		if (requestedUrl !== undefined) {
+			return requestedUrl;
+		}
+	}
+
+	throw new Error(
+		`Default browser did not request the verification URL after ${BROWSER_LAUNCH_ATTEMPTS} launch attempts of ${BROWSER_REQUEST_TIMEOUT_MS}ms each`,
+	);
 }
 
 test(
@@ -62,11 +79,13 @@ test(
 			);
 			assert(result.ok);
 
-			openUrl(result.url);
-
-			const requestedUrl = await waitWithTimeout(
+			// A cold windows-2025 runner once failed to initialize its default browser
+			// within 30s, while the immediate job rerun delivered this URL in 9.4s.
+			// Relaunch once so one-time browser initialization cannot hide the real
+			// end-to-end assertion or turn a persistent opener failure into a pass.
+			const requestedUrl = await openBrowserUntilRequested(
+				result.url,
 				deviceRequest.promise,
-				BROWSER_REQUEST_TIMEOUT_MS,
 			);
 			expect(requestedUrl.pathname).toBe("/device");
 			expect(requestedUrl.searchParams.get("user_code")).toBe("X");
@@ -77,5 +96,5 @@ test(
 		// Above Bun's 5s default so the browser wait inside the test expires first,
 		// producing its descriptive error instead of a generic test timeout.
 	},
-	BROWSER_REQUEST_TIMEOUT_MS + 15_000,
+	BROWSER_REQUEST_TIMEOUT_MS * BROWSER_LAUNCH_ATTEMPTS + 15_000,
 );


### PR DESCRIPTION
## Summary
- retry the real Windows browser launch once after the existing 30-second wait while preserving the complete loopback URL assertion
- restore the Blacksmith `cli-smoke-required` aggregator so failed or cancelled matrix runs fail the required check while non-applicable skipped runs pass

## Test plan
- [x] `bun run verify`
- [x] `bun test ./apps/cli/src/__tests__/browser-opener.test.ts`
- [ ] `windows-2025` browser-opener e2e in CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790243102&installation_model_id=433970&pr_number=463&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F463&signature=84f071d3ff2976b419c3e27fc2af795959d96388eed077a23bbd748246976483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->