### PR TITLE
feat(cli): add R2 multipart upload with client-side secret filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Requires Node.js 20 or newer.
 ```bash
 npm install --global @opalinehq/cli
 opaline login
-opaline enable
+opaline upload
 ```
 
-`opaline login` opens a browser-based device flow. `opaline enable` installs
-the available Claude Code and/or Codex hooks so completed sessions upload
-automatically.
+`opaline login` opens a browser-based device flow. `opaline upload` groups local
+worktrees by repository, lets you choose which repositories stay synchronized,
+installs the required Claude Code and/or Codex hooks, and uploads new sessions.
+`opaline enable` remains a shortcut for enabling the current repository.
 
 Existing `rudel` users do not need to log in again. Opaline intentionally reads
 the existing `~/.rudel` credential and state directory, and the `rudel` package
@@ -45,8 +46,9 @@ opaline disable
 
 - **Sessions:** Claude Code and Codex JSONL transcripts discovered on the local
   machine.
-- **Hooks:** Agent lifecycle commands installed by `opaline enable`. Hooks run
-  headlessly, filter known secret patterns, and upload the completed session.
+- **Hooks:** Agent lifecycle commands installed by `opaline upload` or
+  `opaline enable`. Hooks run headlessly, consult the repository allowlist,
+  filter known secret patterns, and upload the completed session.
 - **Organizations:** The Opaline workspace receiving uploads. Use
   `opaline set-org` to change the organization associated with a project.
 - **Local state:** Credentials, retry queues, logs, and project mappings remain
@@ -64,9 +66,9 @@ opaline disable
 | `opaline logout` | Revoke the current credential and log out locally. |
 | `opaline whoami` | Show the authenticated user and local upload failures. |
 | `opaline doctor` | Run read-only auth, API latency, config, version, and hook diagnostics. |
-| `opaline enable` | Install available Claude Code and Codex upload hooks. |
-| `opaline disable` | Remove Opaline upload hooks. |
-| `opaline upload [session]` | Upload one session or choose past sessions interactively. |
+| `opaline enable` | Enable automatic upload for the current repository. |
+| `opaline disable` | Disable automatic upload and remove Opaline upload hooks. |
+| `opaline upload [session]` | Manage synchronized repositories or upload one session. |
 | `opaline upload --retry` | Retry locally queued transient upload failures. |
 | `opaline set-org` | Set the Opaline organization for the current project. |
 | `opaline --help` | Show complete command and flag help. |
@@ -122,6 +124,12 @@ unusual formats, screenshots, and other sensitive values may not match. Safety
 limits stop an upload when filtering cannot preserve transcript integrity,
 cannot converge, or redacts an unexpectedly large portion of the payload, but
 they cannot prove that the remaining transcript is free of secrets.
+
+When the authenticated server advertises direct R2 ingest support, the CLI
+stages filtered transcript objects in private temporary files and sends them as
+bounded multipart uploads. Servers without that capability continue to receive
+the filtered legacy ingest request; large file-backed requests fail locally
+rather than being materialized without a safe bound.
 
 Keep secrets out of agent sessions, review your organization's data policies,
 and treat filtering as defense in depth. Report security issues through the

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -6,9 +6,14 @@ analytics.
 ```bash
 npm install --global @opalinehq/cli
 opaline login
-opaline enable
+opaline upload
 opaline doctor
 ```
+
+`opaline upload` groups discovered worktrees by repository, saves the selected
+repositories for automatic upload, and sends only sessions the server does not
+already have. `opaline enable` remains available to enable the current
+repository directly.
 
 The CLI keeps using the existing `~/.rudel` state directory so upgrades do not
 require another login. Its production API remains `https://app.rudel.ai`.
@@ -19,3 +24,5 @@ handling disclosure, see the
 
 Important: session transcripts are uploaded. Known-pattern secret filtering is
 best-effort and cannot guarantee that every sensitive value is removed.
+Capable servers use direct multipart object-storage uploads after filtering;
+older servers continue to use the legacy ingest endpoint.

--- a/apps/cli/src/__tests__/auto-upload-config.test.ts
+++ b/apps/cli/src/__tests__/auto-upload-config.test.ts
@@ -1,0 +1,104 @@
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	clearAutoUploadRepositories,
+	getRequiredAutoUploadSources,
+	isRepositoryAutoUploadAllowed,
+	loadAutoUploadConfig,
+	saveVisibleAutoUploadSelections,
+} from "../lib/auto-upload-config.js";
+
+const originalConfigDir = process.env.OPALINE_CONFIG_DIR;
+const tempRoot = await mkdtemp(join(tmpdir(), "rudel-auto-upload-config-"));
+
+beforeAll(() => {
+	process.env.OPALINE_CONFIG_DIR = tempRoot;
+});
+
+beforeEach(async () => {
+	await rm(join(tempRoot, "auto-upload.json"), { force: true });
+});
+
+afterAll(async () => {
+	if (originalConfigDir === undefined) {
+		delete process.env.OPALINE_CONFIG_DIR;
+	} else {
+		process.env.OPALINE_CONFIG_DIR = originalConfigDir;
+	}
+	await rm(tempRoot, { force: true, recursive: true });
+});
+
+describe("repository-scoped automatic upload", () => {
+	test("keeps legacy global hooks allowed until repository choices are saved", () => {
+		expect(loadAutoUploadConfig()).toBeNull();
+		expect(isRepositoryAutoUploadAllowed("path:rudel-v2", "claude_code")).toBe(
+			true,
+		);
+		expect(isRepositoryAutoUploadAllowed("path:other", "codex")).toBe(true);
+	});
+
+	test("persists selected repositories and gates each agent source", async () => {
+		const config = saveVisibleAutoUploadSelections(
+			[
+				{
+					key: "path:rudel-v2",
+					label: "rudel-v2",
+					sources: ["claude_code"],
+				},
+				{
+					key: "remote:github.com/acme/other",
+					label: "acme/other",
+					sources: ["claude_code"],
+				},
+			],
+			new Set(["path:rudel-v2"]),
+		);
+
+		expect(isRepositoryAutoUploadAllowed("path:rudel-v2", "claude_code")).toBe(
+			true,
+		);
+		expect(isRepositoryAutoUploadAllowed("path:rudel-v2", "codex")).toBe(false);
+		expect(
+			isRepositoryAutoUploadAllowed(
+				"remote:github.com/acme/other",
+				"claude_code",
+			),
+		).toBe(false);
+		expect(getRequiredAutoUploadSources(config)).toEqual(
+			new Set(["claude_code"]),
+		);
+		expect((await stat(tempRoot)).mode & 0o777).toBe(0o700);
+		expect((await stat(join(tempRoot, "auto-upload.json"))).mode & 0o777).toBe(
+			0o600,
+		);
+		expect(
+			await readFile(join(tempRoot, "auto-upload.json"), "utf8"),
+		).toContain('"path:rudel-v2"');
+	});
+
+	test("supports turning every repository off", () => {
+		clearAutoUploadRepositories();
+
+		expect(isRepositoryAutoUploadAllowed("path:rudel-v2", "claude_code")).toBe(
+			false,
+		);
+		expect(getRequiredAutoUploadSources(loadRequiredConfig())).toEqual(
+			new Set(),
+		);
+	});
+});
+
+function loadRequiredConfig() {
+	const config = loadAutoUploadConfig();
+	if (!config) throw new Error("Expected auto-upload configuration");
+	return config;
+}

--- a/apps/cli/src/__tests__/auto-upload-hook-gating.integration.test.ts
+++ b/apps/cli/src/__tests__/auto-upload-hook-gating.integration.test.ts
@@ -1,0 +1,33 @@
+import { afterAll, expect, test } from "bun:test";
+import { rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createCliFixture, HOOK_CASES, runCli } from "./helpers/ingest-stub.js";
+
+const fixtureHomes: string[] = [];
+
+afterAll(async () => {
+	await Promise.all(
+		fixtureHomes.map((home) => rm(home, { force: true, recursive: true })),
+	);
+});
+
+test.each(HOOK_CASES)(
+	"$name skips transport when automatic upload is off for the repository",
+	async (hookCase) => {
+		const fixture = await createCliFixture(hookCase.source);
+		fixtureHomes.push(fixture.home);
+		await writeFile(
+			join(fixture.home, ".rudel", "auto-upload.json"),
+			JSON.stringify({ repositories: {}, version: 1 }),
+		);
+		const invocation = hookCase.buildInvocation(fixture);
+
+		const result = await runCli(invocation.command, fixture, {
+			env: { OPALINE_API_BASE: "http://127.0.0.1:1" },
+			stdin: invocation.stdin,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+	},
+);

--- a/apps/cli/src/__tests__/auto-upload-hook-gating.integration.test.ts
+++ b/apps/cli/src/__tests__/auto-upload-hook-gating.integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, expect, test } from "bun:test";
-import { rm, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createCliFixture, HOOK_CASES, runCli } from "./helpers/ingest-stub.js";
 
@@ -21,13 +21,27 @@ test.each(HOOK_CASES)(
 			JSON.stringify({ repositories: {}, version: 1 }),
 		);
 		const invocation = hookCase.buildInvocation(fixture);
+		const fetchLogPath = join(fixture.home, "fetch-counter.log");
+		await writeFile(fetchLogPath, "");
+		const fetchCounterPreload = join(
+			import.meta.dir,
+			"helpers",
+			"fetch-counter-preload.ts",
+		);
 
 		const result = await runCli(invocation.command, fixture, {
-			env: { OPALINE_API_BASE: "http://127.0.0.1:1" },
+			// A preload runs in the spawned CLI process, records its own startup,
+			// and synchronously logs every fetch without requiring a socket listener.
+			env: {
+				OPALINE_API_BASE: "https://transport.invalid",
+				OPALINE_TEST_FETCH_LOG: fetchLogPath,
+			},
+			preload: fetchCounterPreload,
 			stdin: invocation.stdin,
 		});
 
 		expect(result.exitCode).toBe(0);
 		expect(result.stderr).toBe("");
+		expect(await readFile(fetchLogPath, "utf8")).toBe("preloaded\n");
 	},
 );

--- a/apps/cli/src/__tests__/filtered-upload-staging.test.ts
+++ b/apps/cli/src/__tests__/filtered-upload-staging.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FILTER_VERSION } from "../internal/secret-filter/index.js";
+import {
+	cleanupStagedUpload,
+	stageFilteredUpload,
+} from "../lib/filtered-upload-staging.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true })),
+	);
+});
+
+describe("filtered upload staging", () => {
+	test("filters a file source before creating the upload hash", async () => {
+		const sourceDirectory = await mkdtemp(
+			join(tmpdir(), "opaline-filter-source-"),
+		);
+		temporaryDirectories.push(sourceDirectory);
+		const sourcePath = join(sourceDirectory, "transcript.jsonl");
+		const canary = `AKIA${"A".repeat(16)}`;
+		const content = [
+			JSON.stringify({ message: `Use ${canary}`, padding: "x".repeat(200) }),
+			JSON.stringify({ message: "clean second line" }),
+		].join("\n");
+		await writeFile(sourcePath, content);
+
+		const staged = await stageFilteredUpload({
+			main: { kind: "file", path: sourcePath },
+			metadata: {
+				filter_version: FILTER_VERSION,
+				projectPath: "/test/project",
+				sessionId: "filtered-file",
+				source: "claude_code",
+			},
+			subagents: [],
+		});
+		temporaryDirectories.push(staged.directory);
+		const main = staged.objects[0];
+		expect(main?.kind).toBe("main");
+		assert(main);
+		const filtered = await readFile(main.path, "utf8");
+
+		expect(filtered).not.toContain(canary);
+		expect(filtered).toContain("[REDACTED:aws-access-key-id]");
+		expect(staged.redactions).toEqual({ "aws-access-key-id": 1 });
+		expect(staged.redactedBytes).toBe(Buffer.byteLength(canary));
+		expect(main.byteLength).toBe(Buffer.byteLength(filtered));
+		expect(main.sha256).toBe(
+			createHash("sha256").update(filtered).digest("hex"),
+		);
+		expect((await stat(staged.directory)).mode & 0o777).toBe(0o700);
+		expect((await stat(main.path)).mode & 0o777).toBe(0o600);
+
+		await cleanupStagedUpload(staged);
+		temporaryDirectories.splice(
+			temporaryDirectories.indexOf(staged.directory),
+			1,
+		);
+	});
+
+	test("detects secrets when a JSONL record crosses read chunks", async () => {
+		const sourceDirectory = await mkdtemp(
+			join(tmpdir(), "opaline-filter-boundary-"),
+		);
+		temporaryDirectories.push(sourceDirectory);
+		const sourcePath = join(sourceDirectory, "boundary.jsonl");
+		const canary = `AKIA${"B".repeat(16)}`;
+		const content = JSON.stringify({
+			padding: "x".repeat(64 * 1024 - 10),
+			secret: canary,
+		});
+		await writeFile(sourcePath, content);
+
+		const staged = await stageFilteredUpload({
+			main: { kind: "file", path: sourcePath },
+			metadata: {
+				projectPath: "/test/project",
+				sessionId: "chunk-boundary",
+				source: "codex",
+			},
+			subagents: [],
+		});
+		temporaryDirectories.push(staged.directory);
+		const main = staged.objects[0];
+		assert(main);
+		const filtered = await readFile(main.path, "utf8");
+
+		expect(filtered).not.toContain(canary);
+		expect(filtered).toContain("[REDACTED:aws-access-key-id]");
+	});
+
+	test("stages main first and subagent objects in agent ID order", async () => {
+		const staged = await stageFilteredUpload({
+			main: { content: "main", kind: "text" },
+			metadata: {
+				projectPath: "/test/project",
+				sessionId: "sorted-manifest",
+				source: "claude_code",
+			},
+			subagents: [
+				{ agentId: "agent-z", source: { content: "z", kind: "text" } },
+				{ agentId: "agent-a", source: { content: "a", kind: "text" } },
+			],
+		});
+		temporaryDirectories.push(staged.directory);
+
+		expect(
+			staged.objects.map((object) =>
+				object.kind === "main" ? object.kind : object.agentId,
+			),
+		).toEqual(["main", "agent-a", "agent-z"]);
+	});
+
+	test("omits empty subagent objects from the R2 manifest", async () => {
+		const sourceDirectory = await mkdtemp(
+			join(tmpdir(), "opaline-filter-empty-subagent-"),
+		);
+		temporaryDirectories.push(sourceDirectory);
+		const emptySubagentPath = join(sourceDirectory, "empty.jsonl");
+		await writeFile(emptySubagentPath, "");
+
+		const staged = await stageFilteredUpload({
+			main: { content: "main", kind: "text" },
+			metadata: {
+				projectPath: "/test/project",
+				sessionId: "empty-subagent",
+				source: "claude_code",
+			},
+			subagents: [
+				{
+					agentId: "agent-empty-file",
+					source: { kind: "file", path: emptySubagentPath },
+				},
+				{
+					agentId: "agent-empty-text",
+					source: { content: "", kind: "text" },
+				},
+				{
+					agentId: "agent-kept",
+					source: { content: "kept", kind: "text" },
+				},
+			],
+		});
+		temporaryDirectories.push(staged.directory);
+
+		expect(
+			staged.objects.map((object) =>
+				object.kind === "main" ? object.kind : object.agentId,
+			),
+		).toEqual(["main", "agent-kept"]);
+		expect(staged.aggregateBytes).toBe(Buffer.byteLength("mainkept"));
+	});
+});

--- a/apps/cli/src/__tests__/helpers/fetch-counter-preload.ts
+++ b/apps/cli/src/__tests__/helpers/fetch-counter-preload.ts
@@ -1,0 +1,13 @@
+import { appendFileSync } from "node:fs";
+
+const logPath = process.env.OPALINE_TEST_FETCH_LOG;
+if (!logPath) throw new Error("OPALINE_TEST_FETCH_LOG is required");
+
+appendFileSync(logPath, "preloaded\n");
+globalThis.fetch = (input) => {
+	const url = input instanceof Request ? input.url : input.toString();
+	appendFileSync(logPath, `request ${url}\n`);
+	return Promise.reject(
+		new Error(`Unexpected test transport request to ${url}`),
+	);
+};

--- a/apps/cli/src/__tests__/helpers/ingest-stub.ts
+++ b/apps/cli/src/__tests__/helpers/ingest-stub.ts
@@ -24,16 +24,26 @@ export interface IngestStubRespondInfo {
 	readonly requestIndex: number;
 	readonly pathname: string;
 	readonly body: string;
+	readonly bodyBytes: number;
+	readonly headers: Headers;
+	readonly hostname: string;
+	readonly method: string;
 }
 
 export interface IngestStubOptions {
+	/** Defaults to the legacy all-interfaces binding used by existing tests. */
+	readonly hostname?: string;
+	/** Defaults to true for suites that assert the exact request payload. */
+	readonly captureBodies?: boolean;
 	/**
 	 * Fail the first n requests with the given status before serving the
 	 * default success envelope.
 	 */
 	readonly failFirstN?: { readonly n: number; readonly status: number };
 	/** Full custom response control. Takes precedence over failFirstN. */
-	readonly respond?: (info: IngestStubRespondInfo) => Response;
+	readonly respond?: (
+		info: IngestStubRespondInfo,
+	) => Promise<Response> | Response;
 }
 
 export interface IngestStub {
@@ -54,7 +64,7 @@ export function startIngestStub(options: IngestStubOptions = {}): IngestStub {
 	const requests: IngestStubRequest[] = [];
 	const bodies: string[] = [];
 	const server = Bun.serve({
-		hostname: "0.0.0.0",
+		hostname: options.hostname ?? "0.0.0.0",
 		port: 0,
 		async fetch(request) {
 			const url = new URL(request.url);
@@ -64,14 +74,32 @@ export function startIngestStub(options: IngestStubOptions = {}): IngestStub {
 				apiKey: request.headers.get("x-api-key"),
 				pathname: url.pathname,
 			});
-			bodies.push(body);
+			if (options.captureBodies !== false) {
+				bodies.push(body);
+			}
 
 			if (options.respond) {
-				return options.respond({ requestIndex, pathname: url.pathname, body });
+				return options.respond({
+					requestIndex,
+					pathname: url.pathname,
+					body,
+					bodyBytes: Buffer.byteLength(body),
+					headers: request.headers,
+					hostname: url.hostname,
+					method: request.method,
+				});
 			}
 			if (options.failFirstN && requestIndex < options.failFirstN.n) {
 				return new Response("upstream failure", {
 					status: options.failFirstN.status,
+				});
+			}
+			if (url.pathname === "/rpc/cli/sessionUploadStatus") {
+				return Response.json({
+					json: {
+						organizationId: "stub-organization",
+						uploadedSessionIds: [],
+					},
 				});
 			}
 			return Response.json({
@@ -229,6 +257,7 @@ export async function runCli(
 		env: {
 			...process.env,
 			HOME: fixture.home,
+			OPALINE_CONFIG_DIR: join(fixture.home, ".rudel"),
 			USERPROFILE: fixture.home,
 			RUDEL_CONFIG_DIR: join(fixture.home, ".rudel"),
 			POSTHOG_ENABLED: "false",

--- a/apps/cli/src/__tests__/helpers/ingest-stub.ts
+++ b/apps/cli/src/__tests__/helpers/ingest-stub.ts
@@ -250,9 +250,13 @@ export async function runCli(
 	options: {
 		readonly stdin?: string;
 		readonly env?: Readonly<Record<string, string>>;
+		readonly preload?: string;
 	} = {},
 ): Promise<CliResult> {
-	const proc = Bun.spawn(["bun", SOURCE_CLI_PATH, ...args], {
+	const command = ["bun"];
+	if (options.preload) command.push("--preload", options.preload);
+	command.push(SOURCE_CLI_PATH, ...args);
+	const proc = Bun.spawn(command, {
 		cwd: MONOREPO_ROOT,
 		env: {
 			...process.env,

--- a/apps/cli/src/__tests__/helpers/r2-upload-memory-probe.ts
+++ b/apps/cli/src/__tests__/helpers/r2-upload-memory-probe.ts
@@ -160,6 +160,16 @@ const result = await (async () => {
 		{ gitInfo: {}, uploadMode: "manual" },
 	);
 	sampleMemory();
+	if (probeMode === "adapter-scan") {
+		return {
+			attempts: 0,
+			error: undefined,
+			redacted: {},
+			redactedBytes: 0,
+			retryable: undefined,
+			success: true as const,
+		};
+	}
 	return uploadSession(request, {
 		allowInsecureEndpoint: false,
 		authType: "api-key",

--- a/apps/cli/src/__tests__/helpers/r2-upload-memory-probe.ts
+++ b/apps/cli/src/__tests__/helpers/r2-upload-memory-probe.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import { codexAdapter } from "../../internal/agent-adapters/index.js";
+import { R2_INGEST_PART_SIZE_BYTES } from "../../lib/r2-ingest-contract.js";
+import { buildFilePartRanges } from "../../lib/r2-multipart-upload.js";
+import { uploadSession } from "../../lib/uploader.js";
+
+const [transcriptPath, endpoint, token, sessionId] = process.argv.slice(2);
+if (!transcriptPath || !endpoint || !token || !sessionId) {
+	throw new Error(
+		"Expected transcript path, endpoint, token, and session ID arguments",
+	);
+}
+
+const probeMode = process.env.OPALINE_R2_PROBE_MODE;
+const requestPaths: string[] = [];
+let initByteLength = 0;
+let initSha256 = "";
+let uploadedBytes = 0;
+let uploadedPartCount = 0;
+let uploadedPrefix = "";
+const uploadedHash = createHash("sha256");
+
+if (probeMode === "success" || probeMode === "failed-init") {
+	globalThis.fetch = async (input, init) => {
+		const request = new Request(input, init);
+		const pathname = new URL(request.url).pathname;
+		requestPaths.push(pathname);
+		if (probeMode === "failed-init") {
+			return Response.json(
+				{
+					json: {
+						code: "SERVICE_UNAVAILABLE",
+						defined: false,
+						message: "R2 initialization temporarily unavailable",
+						status: 503,
+					},
+				},
+				{ status: 503 },
+			);
+		}
+		if (pathname.startsWith("/r2/probe/part/")) {
+			uploadedPartCount += 1;
+			if (request.body) {
+				for await (const chunk of request.body) {
+					uploadedBytes += chunk.byteLength;
+					uploadedHash.update(chunk);
+					if (uploadedPrefix.length < 4 * 1024) {
+						uploadedPrefix += Buffer.from(chunk).toString("utf8");
+						uploadedPrefix = uploadedPrefix.slice(0, 4 * 1024);
+					}
+				}
+			}
+			return new Response(null, {
+				headers: { etag: `"probe-${uploadedPartCount}"` },
+			});
+		}
+		const parsed = (await request.json()) as {
+			json: Record<string, unknown>;
+		};
+		if (pathname === "/rpc/ingest/init") {
+			const objects = parsed.json.objects;
+			if (!Array.isArray(objects)) throw new Error("Missing probe objects");
+			const main = objects.find(
+				(object) =>
+					typeof object === "object" &&
+					object !== null &&
+					"kind" in object &&
+					object.kind === "main",
+			) as Record<string, unknown> | undefined;
+			if (
+				!main ||
+				typeof main.byteLength !== "number" ||
+				typeof main.sha256 !== "string"
+			) {
+				throw new Error("Missing probe main object");
+			}
+			initByteLength = main.byteLength;
+			initSha256 = main.sha256;
+			const parts = buildFilePartRanges(
+				initByteLength,
+				R2_INGEST_PART_SIZE_BYTES,
+			).map((range) => ({
+				byteLength: range.byteLength,
+				headers: { "Content-Length": range.byteLength.toString() },
+				partNumber: range.partNumber,
+				uploadUrl: `http://127.0.0.1/r2/probe/part/${range.partNumber}`,
+			}));
+			return Response.json({
+				json: {
+					expiresAt: "2026-08-25T12:15:00.000Z",
+					jobId: "00000000-0000-4000-8000-000000000001",
+					objects: [
+						{
+							byteLength: initByteLength,
+							kind: "main",
+							objectKey: "ingest/probe/main.jsonl",
+							parts,
+							sha256: initSha256,
+							uploadId: "probe-upload",
+						},
+					],
+					partSizeBytes: R2_INGEST_PART_SIZE_BYTES,
+					protocol: "r2_multipart_v1",
+				},
+			});
+		}
+		const success = {
+			redacted: {},
+			redactedBytes: 0,
+			sessionId,
+			success: true,
+		};
+		if (pathname === "/rpc/ingest/commit") {
+			return Response.json({
+				json: {
+					jobId: "00000000-0000-4000-8000-000000000001",
+					protocol: "r2_multipart_v1",
+					result: success,
+					status: "completed",
+				},
+			});
+		}
+		if (pathname === "/rpc/ingest/status") {
+			return Response.json({
+				json: {
+					attempts: 1,
+					availableAt: "2026-08-25T12:00:00.000Z",
+					error: null,
+					jobId: "00000000-0000-4000-8000-000000000001",
+					leaseExpiresAt: null,
+					protocol: "r2_multipart_v1",
+					result: success,
+					status: "completed",
+					updatedAt: "2026-08-25T12:00:01.000Z",
+				},
+			});
+		}
+		return new Response("not found", { status: 404 });
+	};
+}
+
+Bun.gc(true);
+const baseline = process.memoryUsage();
+let peakHeapUsed = baseline.heapUsed;
+let peakRss = baseline.rss;
+const sampleMemory = () => {
+	const usage = process.memoryUsage();
+	peakHeapUsed = Math.max(peakHeapUsed, usage.heapUsed);
+	peakRss = Math.max(peakRss, usage.rss);
+};
+const interval = setInterval(sampleMemory, 2);
+
+const result = await (async () => {
+	const request = await codexAdapter.buildUploadRequest(
+		{
+			projectPath: "/test/large-r2-project",
+			sessionId,
+			transcriptPath,
+		},
+		{ gitInfo: {}, uploadMode: "manual" },
+	);
+	sampleMemory();
+	return uploadSession(request, {
+		allowInsecureEndpoint: false,
+		authType: "api-key",
+		endpoint,
+		onProgress: sampleMemory,
+		r2MultipartBaseDelayMs: 0,
+		r2StatusPollIntervalMs: 0,
+		token,
+	});
+})().finally(() => clearInterval(interval));
+sampleMemory();
+
+process.stdout.write(
+	JSON.stringify({
+		attempts: result.attempts,
+		awsRedactions: result.redacted?.["aws-access-key-id"] ?? 0,
+		baselineHeapUsed: baseline.heapUsed,
+		baselineRss: baseline.rss,
+		heapDelta: peakHeapUsed - baseline.heapUsed,
+		initByteLength,
+		initSha256,
+		error: result.success ? null : result.error,
+		peakHeapUsed,
+		peakRss,
+		redactedBytes: result.redactedBytes,
+		retryable: result.retryable ?? null,
+		rssDelta: peakRss - baseline.rss,
+		success: result.success,
+		uploadedBytes,
+		uploadedHash: uploadedPartCount > 0 ? uploadedHash.digest("hex") : "",
+		uploadedPartCount,
+		uploadedPrefix,
+		requestPaths,
+	}),
+);

--- a/apps/cli/src/__tests__/r2-multipart-upload.test.ts
+++ b/apps/cli/src/__tests__/r2-multipart-upload.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	R2IngestUploadObject,
+	R2IngestUploadPart,
+} from "../lib/r2-ingest-contract.js";
+import {
+	buildFilePartRanges,
+	inspectUploadFile,
+	uploadR2MultipartObjects,
+} from "../lib/r2-multipart-upload.js";
+
+const temporaryDirectories: string[] = [];
+const activeIntervals: Array<ReturnType<typeof setInterval>> = [];
+
+afterEach(async () => {
+	for (const interval of activeIntervals.splice(0)) clearInterval(interval);
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true })),
+	);
+});
+
+describe("R2 multipart file handling", () => {
+	test("splits files into exact byte ranges", () => {
+		expect(buildFilePartRanges(18, 8)).toEqual([
+			{ byteLength: 8, end: 7, partNumber: 1, start: 0 },
+			{ byteLength: 8, end: 15, partNumber: 2, start: 8 },
+			{ byteLength: 2, end: 17, partNumber: 3, start: 16 },
+		]);
+	});
+
+	test("computes SHA-256 and byte length without changing the file", async () => {
+		const directory = await createTemporaryDirectory();
+		const path = join(directory, "digest.jsonl");
+		const content = "abc\n€\n";
+		await writeFile(path, content);
+
+		expect(await inspectUploadFile(path)).toEqual({
+			byteLength: Buffer.byteLength(content),
+			sha256: createHash("sha256").update(content).digest("hex"),
+		});
+	});
+
+	test("retries a transient PUT with the same signed Content-Length", async () => {
+		const directory = await createTemporaryDirectory();
+		const path = join(directory, "retry.jsonl");
+		const content = "retry-body";
+		await writeFile(path, content);
+		const receivedLengths: string[] = [];
+		const receivedBodies: string[] = [];
+		const retries: number[] = [];
+		const fetchMock: typeof fetch = async (input, init) => {
+			const request = new Request(input, init);
+			receivedLengths.push(request.headers.get("content-length") ?? "");
+			receivedBodies.push(await request.text());
+			if (receivedBodies.length === 1) {
+				return new Response("try again", { status: 503 });
+			}
+			return new Response(null, { headers: { etag: '"retry-etag"' } });
+		};
+		const upload = createUploadObject(content.length, "https://r2.test/part/1");
+
+		const result = await uploadR2MultipartObjects({
+			baseDelayMs: 0,
+			fetch: fetchMock,
+			maxAttempts: 3,
+			onProgress: undefined,
+			onRetry: (retry) => retries.push(retry.attempt),
+			sources: [{ path, upload }],
+		});
+
+		expect(receivedBodies).toEqual([content, content]);
+		expect(receivedLengths).toEqual(
+			Array.from({ length: 2 }, () => content.length.toString()),
+		);
+		expect(retries).toEqual([1]);
+		expect(result).toEqual({
+			attempts: 2,
+			objects: [
+				{
+					objectKey: upload.objectKey,
+					parts: [{ etag: '"retry-etag"', partNumber: 1 }],
+					uploadId: upload.uploadId,
+				},
+			],
+		});
+	});
+
+	test("streams a file larger than 100 MiB with bounded ArrayBuffer memory", async () => {
+		const directory = await createTemporaryDirectory();
+		const path = join(directory, "large-transcript.jsonl");
+		const byteLength = 101 * 1024 * 1024 + 17;
+		const partSizeBytes = 8 * 1024 * 1024;
+		await writeFile(path, "");
+		await truncate(path, byteLength);
+		const receivedPartBytes: number[] = [];
+		const fetchMock: typeof fetch = async (input, init) => {
+			const request = new Request(input, init);
+			let received = 0;
+			if (request.body) {
+				for await (const chunk of request.body) {
+					received += chunk.byteLength;
+				}
+			}
+			receivedPartBytes.push(received);
+			return new Response(null, {
+				headers: { etag: `"part-${receivedPartBytes.length}"` },
+			});
+		};
+		const ranges = buildFilePartRanges(byteLength, partSizeBytes);
+		const parts: R2IngestUploadPart[] = ranges.map((range) => ({
+			byteLength: range.byteLength,
+			headers: { "Content-Length": range.byteLength.toString() },
+			partNumber: range.partNumber,
+			uploadUrl: `https://r2.test/part/${range.partNumber}`,
+		}));
+		const upload: R2IngestUploadObject = {
+			byteLength,
+			kind: "main",
+			objectKey: "ingest/large/main.jsonl",
+			parts,
+			sha256: "a".repeat(64),
+			uploadId: "large-upload",
+		};
+		Bun.gc(true);
+		const baseline = process.memoryUsage().arrayBuffers;
+		let peak = baseline;
+		const sampleMemory = () => {
+			peak = Math.max(peak, process.memoryUsage().arrayBuffers);
+		};
+		const interval = setInterval(sampleMemory, 2);
+		activeIntervals.push(interval);
+
+		const result = await uploadR2MultipartObjects({
+			baseDelayMs: 50,
+			fetch: fetchMock,
+			maxAttempts: 3,
+			onProgress: sampleMemory,
+			onRetry: undefined,
+			sources: [{ path, upload }],
+		});
+		clearInterval(interval);
+		activeIntervals.splice(activeIntervals.indexOf(interval), 1);
+
+		expect(receivedPartBytes).toEqual(ranges.map((range) => range.byteLength));
+		expect(result.objects[0]?.parts).toHaveLength(ranges.length);
+		expect(peak - baseline).toBeLessThan(64 * 1024 * 1024);
+	}, 60_000);
+});
+
+async function createTemporaryDirectory(): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "opaline-r2-test-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+function createUploadObject(
+	byteLength: number,
+	uploadUrl: string,
+): R2IngestUploadObject {
+	return {
+		byteLength,
+		kind: "main",
+		objectKey: "ingest/test/main.jsonl",
+		parts: [
+			{
+				byteLength,
+				headers: { "Content-Length": byteLength.toString() },
+				partNumber: 1,
+				uploadUrl,
+			},
+		],
+		sha256: "a".repeat(64),
+		uploadId: "test-upload",
+	};
+}

--- a/apps/cli/src/__tests__/r2-staging-cleanup.test.ts
+++ b/apps/cli/src/__tests__/r2-staging-cleanup.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { access, mkdir, mkdtemp, rm, stat, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	R2_PART_STAGING_DIRECTORY_PREFIX,
+	R2_UPLOAD_STAGING_DIRECTORY_PREFIX,
+	scavengeStaleR2StagingDirectories,
+} from "../lib/r2-staging-cleanup.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true })),
+	);
+});
+
+describe("R2 staging cleanup", () => {
+	test("removes stale owned staging directories and ignores fresh, foreign, and non-owned directories", async () => {
+		const root = await mkdtemp(join(tmpdir(), "opaline-r2-scavenger-test-"));
+		temporaryDirectories.push(root);
+		const staleUpload = join(root, `${R2_UPLOAD_STAGING_DIRECTORY_PREFIX}old`);
+		const stalePart = join(root, `${R2_PART_STAGING_DIRECTORY_PREFIX}old`);
+		const freshUpload = join(
+			root,
+			`${R2_UPLOAD_STAGING_DIRECTORY_PREFIX}fresh`,
+		);
+		const foreign = join(root, "foreign-r2-upload-old");
+		await Promise.all(
+			[staleUpload, stalePart, freshUpload, foreign].map((directory) =>
+				mkdir(directory),
+			),
+		);
+		const oldDate = new Date(Date.now() - 2 * 60 * 60 * 1_000);
+		await Promise.all(
+			[staleUpload, stalePart, foreign].map((directory) =>
+				utimes(directory, oldDate, oldDate),
+			),
+		);
+		const ownerUid = (await stat(staleUpload)).uid;
+
+		const removed = await scavengeStaleR2StagingDirectories({
+			ownerUid,
+			staleBeforeMs: Date.now() - 60 * 60 * 1_000,
+			temporaryDirectory: root,
+		});
+
+		expect(new Set(removed)).toEqual(new Set([staleUpload, stalePart]));
+		await expect(access(staleUpload)).rejects.toThrow();
+		await expect(access(stalePart)).rejects.toThrow();
+		await expect(access(freshUpload)).resolves.toBeNull();
+		await expect(access(foreign)).resolves.toBeNull();
+
+		const nonOwned = join(
+			root,
+			`${R2_UPLOAD_STAGING_DIRECTORY_PREFIX}non-owned`,
+		);
+		await mkdir(nonOwned);
+		await utimes(nonOwned, oldDate, oldDate);
+		const nonOwnerResult = await scavengeStaleR2StagingDirectories({
+			ownerUid: ownerUid + 1,
+			staleBeforeMs: Date.now() - 60 * 60 * 1_000,
+			temporaryDirectory: root,
+		});
+
+		expect(nonOwnerResult).toEqual([]);
+		await expect(access(nonOwned)).resolves.toBeNull();
+	});
+});

--- a/apps/cli/src/__tests__/r2-upload-flow.test.ts
+++ b/apps/cli/src/__tests__/r2-upload-flow.test.ts
@@ -505,6 +505,58 @@ describe("capability-gated R2 upload flow", () => {
 		expect(memory.requestPaths).not.toContain("/rpc/ingestSession");
 	}, 120_000);
 
+	test("finds a timestamp after a 100+ MiB record with bounded heap and RSS", async () => {
+		const directory = await mkdtemp(
+			join(tmpdir(), "opaline-r2-e2e-oversized-record-"),
+		);
+		temporaryDirectories.push(directory);
+		const transcriptPath = join(
+			directory,
+			"oversized-record-codex-session.jsonl",
+		);
+		const transcriptBytes = await writeCodexTranscriptWithOversizedFirstRecord(
+			transcriptPath,
+			LARGE_TRANSCRIPT_MIN_BYTES,
+		);
+		expect(transcriptBytes).toBeGreaterThan(LARGE_TRANSCRIPT_MIN_BYTES);
+
+		const probePath = join(
+			import.meta.dir,
+			"helpers",
+			"r2-upload-memory-probe.ts",
+		);
+		const probe = Bun.spawn(
+			[
+				"bun",
+				probePath,
+				transcriptPath,
+				"https://app.rudel.ai/rpc",
+				TOKEN,
+				"oversized-record-codex-session",
+			],
+			{
+				env: { ...process.env, OPALINE_R2_PROBE_MODE: "adapter-scan" },
+				stderr: "pipe",
+				stdout: "pipe",
+			},
+		);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			probe.exited,
+			new Response(probe.stdout).text(),
+			new Response(probe.stderr).text(),
+		]);
+		const resourceUsage = probe.resourceUsage();
+		const memory = parseMemoryProbe(stdout);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		expect(memory.success).toBe(true);
+		expect(memory.heapDelta).toBeLessThan(MAX_HEAP_DELTA_BYTES);
+		expect(memory.rssDelta).toBeLessThan(MAX_RSS_DELTA_BYTES);
+		expect(resourceUsage.maxRSS).toBeLessThan(MAX_PROCESS_RSS_BYTES);
+		expect(memory.requestPaths).toEqual([]);
+	}, 120_000);
+
 	test("keeps a 100+ MiB failed R2 init bounded and retryable without legacy fallback", async () => {
 		await isolateCapabilityCache();
 		const directory = await mkdtemp(
@@ -950,6 +1002,36 @@ async function writeCodexTranscriptAtLeast(
 		while (byteLength <= minimumBytes) {
 			byteLength += await writeCompleteBuffer(file, paddingRecord);
 		}
+	} finally {
+		await file.close();
+	}
+	return (await stat(path)).size;
+}
+
+async function writeCodexTranscriptWithOversizedFirstRecord(
+	path: string,
+	minimumRecordBytes: number,
+): Promise<number> {
+	const file = await open(path, "wx", 0o600);
+	try {
+		let recordBytes = await writeCompleteBuffer(
+			file,
+			Buffer.from('{"type":"response_item","message":"'),
+		);
+		const padding = Buffer.alloc(64 * 1024, "x");
+		while (recordBytes < minimumRecordBytes) {
+			recordBytes += await writeCompleteBuffer(file, padding);
+		}
+		await writeCompleteBuffer(file, Buffer.from('"}\n'));
+		await writeCompleteBuffer(
+			file,
+			Buffer.from(
+				`${JSON.stringify({
+					timestamp: "2026-08-25T12:00:00.000Z",
+					type: "event_msg",
+				})}\n`,
+			),
+		);
 	} finally {
 		await file.close();
 	}

--- a/apps/cli/src/__tests__/r2-upload-flow.test.ts
+++ b/apps/cli/src/__tests__/r2-upload-flow.test.ts
@@ -1,0 +1,1014 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+	type FileHandle,
+	mkdtemp,
+	open,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IngestSessionInput } from "../contracts/index.js";
+import type { FileBackedUploadRequest } from "../internal/agent-adapters/index.js";
+import {
+	R2_INGEST_PART_SIZE_BYTES,
+	type R2IngestUploadPart,
+} from "../lib/r2-ingest-contract.js";
+import { buildFilePartRanges } from "../lib/r2-multipart-upload.js";
+import {
+	hasAdvertisedR2UploadCapability,
+	rememberR2UploadCapability,
+} from "../lib/r2-upload-capability.js";
+import { type UploadConfig, uploadSession } from "../lib/uploader.js";
+
+const TOKEN = "r2-flow-test-token";
+const JOB_ID = "00000000-0000-4000-8000-000000000001";
+const activeServers: Array<FetchStub> = [];
+const temporaryDirectories: string[] = [];
+const originalConfigDirectory = process.env.OPALINE_CONFIG_DIR;
+const LARGE_TRANSCRIPT_MIN_BYTES = 101 * 1024 * 1024;
+const LEGACY_CAP_TEST_MIN_BYTES = 33 * 1024 * 1024;
+const MAX_HEAP_DELTA_BYTES = 64 * 1024 * 1024;
+const MAX_RSS_DELTA_BYTES = 160 * 1024 * 1024;
+const MAX_PROCESS_RSS_BYTES = 256 * 1024 * 1024;
+const MAX_FAILED_INIT_RSS_DELTA_BYTES = 96 * 1024 * 1024;
+const MAX_FAILED_INIT_PROCESS_RSS_BYTES = 192 * 1024 * 1024;
+
+interface MemoryProbe {
+	readonly attempts: number;
+	readonly awsRedactions: number;
+	readonly error: string | null;
+	readonly heapDelta: number;
+	readonly initByteLength: number;
+	readonly initSha256: string;
+	readonly requestPaths: readonly string[];
+	readonly retryable: boolean | null;
+	readonly rssDelta: number;
+	readonly success: boolean;
+	readonly uploadedBytes: number;
+	readonly uploadedHash: string;
+	readonly uploadedPartCount: number;
+	readonly uploadedPrefix: string;
+}
+
+afterEach(async () => {
+	await Promise.all(activeServers.splice(0).map((server) => server.stop(true)));
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { force: true, recursive: true })),
+	);
+	if (originalConfigDirectory === undefined) {
+		delete process.env.OPALINE_CONFIG_DIR;
+	} else {
+		process.env.OPALINE_CONFIG_DIR = originalConfigDirectory;
+	}
+});
+
+describe("capability-gated R2 upload flow", () => {
+	test("filters before init and direct upload, then commits and checks status", async () => {
+		await isolateCapabilityCache();
+		const requests: string[] = [];
+		const rpcInputs = new Map<string, Record<string, unknown>>();
+		let uploadedBody = "";
+		let uploadedContentLength = "";
+		let statusCalls = 0;
+		let server: FetchStub;
+		server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				const pathname = new URL(request.url).pathname;
+				requests.push(pathname);
+				if (pathname === "/r2/part/1") {
+					uploadedContentLength = request.headers.get("content-length") ?? "";
+					uploadedBody = await request.text();
+					return new Response(null, { headers: { etag: '"etag-1"' } });
+				}
+
+				const input = await readRpcInput(request);
+				rpcInputs.set(pathname, input);
+				if (pathname === "/rpc/ingestSession") {
+					return rpcResponse({
+						success: true,
+						sessionId: getRequiredString(input, "sessionId"),
+						upgradeHint: { protocol: "r2_multipart_v1" },
+					});
+				}
+				if (pathname === "/rpc/ingest/init") {
+					const main = getMainObject(input);
+					const byteLength = getRequiredNumber(main, "byteLength");
+					return rpcResponse({
+						expiresAt: "2026-08-25T12:15:00.000Z",
+						jobId: JOB_ID,
+						objects: [
+							{
+								byteLength,
+								kind: "main",
+								objectKey: `ingest/${JOB_ID}/main.jsonl`,
+								parts: [
+									{
+										byteLength,
+										headers: {
+											"Content-Length": byteLength.toString(),
+										},
+										partNumber: 1,
+										uploadUrl: `http://127.0.0.1:${server.port}/r2/part/1`,
+									},
+								],
+								sha256: getRequiredString(main, "sha256"),
+								uploadId: "upload-1",
+							},
+						],
+						partSizeBytes: 8 * 1024 * 1024,
+						protocol: "r2_multipart_v1",
+					});
+				}
+				if (pathname === "/rpc/ingest/commit") {
+					return rpcResponse({
+						jobId: JOB_ID,
+						protocol: "r2_multipart_v1",
+						result: createSuccessResult("r2-secret-session"),
+						status: "completed",
+					});
+				}
+				if (pathname === "/rpc/ingest/status") {
+					statusCalls += 1;
+					return rpcResponse({
+						attempts: 1,
+						availableAt: "2026-08-25T12:00:00.000Z",
+						error: null,
+						jobId: JOB_ID,
+						leaseExpiresAt: null,
+						protocol: "r2_multipart_v1",
+						result:
+							statusCalls === 1
+								? null
+								: createSuccessResult("r2-secret-session"),
+						status: statusCalls === 1 ? "pending" : "completed",
+						updatedAt: "2026-08-25T12:00:01.000Z",
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+
+		const warmup = await uploadSession(
+			createRequest("r2-warmup", "clean"),
+			config,
+		);
+		expect(warmup.success).toBe(true);
+
+		const canary = `AKIA${"A".repeat(16)}`;
+		const dirtyContent = JSON.stringify({
+			content: `Use ${canary}`,
+			padding: "x".repeat(200),
+			timestamp: "2026-08-25T12:00:00.000Z",
+			type: "user",
+		});
+		const result = await uploadSession(
+			createRequest("r2-secret-session", dirtyContent),
+			config,
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			redacted: { "aws-access-key-id": 1 },
+			redactedBytes: Buffer.byteLength(canary),
+		});
+		expect(requests).toEqual([
+			"/rpc/ingestSession",
+			"/rpc/ingest/init",
+			"/r2/part/1",
+			"/rpc/ingest/commit",
+			"/rpc/ingest/status",
+			"/rpc/ingest/status",
+		]);
+		expect(uploadedBody).not.toContain(canary);
+		expect(uploadedBody).toContain("[REDACTED:aws-access-key-id]");
+		expect(uploadedContentLength).toBe(
+			Buffer.byteLength(uploadedBody).toString(),
+		);
+
+		const initInput = getRequiredMapValue(rpcInputs, "/rpc/ingest/init");
+		const main = getMainObject(initInput);
+		expect(getRequiredNumber(main, "byteLength")).toBe(
+			Buffer.byteLength(uploadedBody),
+		);
+		expect(getRequiredString(main, "sha256")).toBe(
+			createHash("sha256").update(uploadedBody).digest("hex"),
+		);
+		expect(initInput.content).toBeUndefined();
+		expect(initInput.subagents).toBeUndefined();
+
+		const commitInput = getRequiredMapValue(rpcInputs, "/rpc/ingest/commit");
+		expect(commitInput).toEqual({
+			jobId: JOB_ID,
+			objects: [
+				{
+					objectKey: `ingest/${JOB_ID}/main.jsonl`,
+					parts: [{ etag: '"etag-1"', partNumber: 1 }],
+					uploadId: "upload-1",
+				},
+			],
+		});
+	});
+
+	test("rejects an over-budget streamed transcript before R2 init or PUT while a normal transcript passes", async () => {
+		await isolateCapabilityCache();
+		const directory = await mkdtemp(join(tmpdir(), "opaline-r2-budget-"));
+		temporaryDirectories.push(directory);
+		const normalPath = join(directory, "normal.jsonl");
+		const overBudgetPath = join(directory, "over-budget.jsonl");
+		const normalContent = JSON.stringify({ message: "clean transcript" });
+		const secret = `sk_live_${"a".repeat(13)}`;
+		const overBudgetContent = JSON.stringify({ message: secret });
+		await Promise.all([
+			writeFile(normalPath, normalContent),
+			writeFile(overBudgetPath, overBudgetContent),
+		]);
+
+		const requestPaths: string[] = [];
+		let uploadedBody = "";
+		let server: FetchStub;
+		server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				const pathname = new URL(request.url).pathname;
+				requestPaths.push(pathname);
+				if (pathname === "/r2/budget/part/1") {
+					uploadedBody = await request.text();
+					return new Response(null, { headers: { etag: '"budget-etag"' } });
+				}
+
+				const input = await readRpcInput(request);
+				if (pathname === "/rpc/ingestSession") {
+					return rpcResponse({
+						sessionId: getRequiredString(input, "sessionId"),
+						success: true,
+						upgradeHint: { protocol: "r2_multipart_v1" },
+					});
+				}
+				if (pathname === "/rpc/ingest/init") {
+					const main = getMainObject(input);
+					const byteLength = getRequiredNumber(main, "byteLength");
+					return rpcResponse({
+						expiresAt: "2026-08-25T12:15:00.000Z",
+						jobId: JOB_ID,
+						objects: [
+							{
+								byteLength,
+								kind: "main",
+								objectKey: `ingest/${JOB_ID}/main.jsonl`,
+								parts: [
+									{
+										byteLength,
+										headers: {
+											"Content-Length": byteLength.toString(),
+										},
+										partNumber: 1,
+										uploadUrl: `http://127.0.0.1:${server.port}/r2/budget/part/1`,
+									},
+								],
+								sha256: getRequiredString(main, "sha256"),
+								uploadId: "budget-upload",
+							},
+						],
+						partSizeBytes: R2_INGEST_PART_SIZE_BYTES,
+						protocol: "r2_multipart_v1",
+					});
+				}
+				if (pathname === "/rpc/ingest/commit") {
+					return rpcResponse({
+						jobId: JOB_ID,
+						protocol: "r2_multipart_v1",
+						result: createSuccessResult("normal-streamed"),
+						status: "completed",
+					});
+				}
+				if (pathname === "/rpc/ingest/status") {
+					return rpcResponse({
+						attempts: 1,
+						availableAt: "2026-08-25T12:00:00.000Z",
+						error: null,
+						jobId: JOB_ID,
+						leaseExpiresAt: null,
+						protocol: "r2_multipart_v1",
+						result: createSuccessResult("normal-streamed"),
+						status: "completed",
+						updatedAt: "2026-08-25T12:00:01.000Z",
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+
+		const advertised = await uploadSession(
+			createRequest("budget-r2-warmup", "clean"),
+			config,
+		);
+		expect(advertised.success).toBe(true);
+		requestPaths.length = 0;
+
+		const normal = await uploadSession(
+			createFileRequest("normal-streamed", normalPath),
+			config,
+		);
+		expect(normal.success).toBe(true);
+		expect(uploadedBody).toBe(normalContent);
+		expect(requestPaths).toEqual([
+			"/rpc/ingest/init",
+			"/r2/budget/part/1",
+			"/rpc/ingest/commit",
+			"/rpc/ingest/status",
+		]);
+		requestPaths.length = 0;
+
+		const rejected = await uploadSession(
+			createFileRequest("over-budget-streamed", overBudgetPath),
+			config,
+		);
+		expect(rejected).toEqual({
+			success: false,
+			error:
+				"Redaction safety check stopped upload: known-pattern redaction would replace 21 B of 35 B (60.0%), above the 20% transcript budget (stripe-access-token). The unfiltered transcript was not uploaded.",
+			attempts: 0,
+			redactionBudgetExceeded: true,
+			retryable: false,
+		});
+		expect(requestPaths).toEqual([]);
+	});
+
+	test("streams a 100+ MiB adapter request through filtering, init, and multipart with bounded heap and RSS", async () => {
+		await isolateCapabilityCache();
+		const directory = await mkdtemp(join(tmpdir(), "opaline-r2-e2e-large-"));
+		temporaryDirectories.push(directory);
+		const transcriptPath = join(directory, "large-codex-session.jsonl");
+		const canary = `AKIA${"L".repeat(16)}`;
+		const transcriptBytes = await writeCodexTranscriptAtLeast(
+			transcriptPath,
+			canary,
+			LARGE_TRANSCRIPT_MIN_BYTES,
+		);
+		expect(transcriptBytes).toBeGreaterThan(LARGE_TRANSCRIPT_MIN_BYTES);
+
+		const requestPaths: string[] = [];
+		let initMain: Record<string, unknown> | undefined;
+		let uploadedPartCount = 0;
+		const uploadedHash = createHash("sha256");
+		const uploadedPrefixChunks: Buffer[] = [];
+		let uploadedPrefixBytes = 0;
+		let server: FetchStub;
+		server = serveFetchStub({
+			hostname: "127.0.0.1",
+			idleTimeout: 60,
+			port: 0,
+			async fetch(request) {
+				const pathname = new URL(request.url).pathname;
+				requestPaths.push(pathname);
+				if (pathname.startsWith("/r2/large/part/")) {
+					uploadedPartCount += 1;
+					if (request.body) {
+						for await (const chunk of request.body) {
+							uploadedHash.update(chunk);
+							if (uploadedPrefixBytes < 4 * 1024) {
+								const remaining = 4 * 1024 - uploadedPrefixBytes;
+								const prefix = Buffer.from(chunk.subarray(0, remaining));
+								uploadedPrefixChunks.push(prefix);
+								uploadedPrefixBytes += prefix.byteLength;
+							}
+						}
+					}
+					return new Response(null, {
+						headers: { etag: `"large-${uploadedPartCount}"` },
+					});
+				}
+
+				const input = await readRpcInput(request);
+				if (pathname === "/rpc/ingestSession") {
+					return rpcResponse({
+						sessionId: getRequiredString(input, "sessionId"),
+						success: true,
+						upgradeHint: { protocol: "r2_multipart_v1" },
+					});
+				}
+				if (pathname === "/rpc/ingest/init") {
+					initMain = getMainObject(input);
+					const byteLength = getRequiredNumber(initMain, "byteLength");
+					const parts: R2IngestUploadPart[] = buildFilePartRanges(
+						byteLength,
+						R2_INGEST_PART_SIZE_BYTES,
+					).map((range) => ({
+						byteLength: range.byteLength,
+						headers: { "Content-Length": range.byteLength.toString() },
+						partNumber: range.partNumber,
+						uploadUrl: `http://127.0.0.1:${server.port}/r2/large/part/${range.partNumber}`,
+					}));
+					return rpcResponse({
+						expiresAt: "2026-08-25T12:15:00.000Z",
+						jobId: JOB_ID,
+						objects: [
+							{
+								byteLength,
+								kind: "main",
+								objectKey: `ingest/${JOB_ID}/main.jsonl`,
+								parts,
+								sha256: getRequiredString(initMain, "sha256"),
+								uploadId: "large-upload",
+							},
+						],
+						partSizeBytes: R2_INGEST_PART_SIZE_BYTES,
+						protocol: "r2_multipart_v1",
+					});
+				}
+				if (pathname === "/rpc/ingest/commit") {
+					return rpcResponse({
+						jobId: JOB_ID,
+						protocol: "r2_multipart_v1",
+						result: createSuccessResult("large-codex-session"),
+						status: "completed",
+					});
+				}
+				if (pathname === "/rpc/ingest/status") {
+					return rpcResponse({
+						attempts: 1,
+						availableAt: "2026-08-25T12:00:00.000Z",
+						error: null,
+						jobId: JOB_ID,
+						leaseExpiresAt: null,
+						protocol: "r2_multipart_v1",
+						result: createSuccessResult("large-codex-session"),
+						status: "completed",
+						updatedAt: "2026-08-25T12:00:01.000Z",
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+		const warmup = await uploadSession(
+			createRequest("large-r2-warmup", "clean"),
+			config,
+		);
+		expect(warmup.success).toBe(true);
+		requestPaths.length = 0;
+
+		const probePath = join(
+			import.meta.dir,
+			"helpers",
+			"r2-upload-memory-probe.ts",
+		);
+		const probe = Bun.spawn(
+			[
+				"bun",
+				probePath,
+				transcriptPath,
+				config.endpoint,
+				TOKEN,
+				"large-codex-session",
+			],
+			{
+				env: { ...process.env, OPALINE_R2_PROBE_MODE: "success" },
+				stderr: "pipe",
+				stdout: "pipe",
+			},
+		);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			probe.exited,
+			new Response(probe.stdout).text(),
+			new Response(probe.stderr).text(),
+		]);
+		const resourceUsage = probe.resourceUsage();
+		const memory = parseMemoryProbe(stdout);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		expect(memory.success).toBe(true);
+		expect(memory.awsRedactions).toBe(1);
+		expect(memory.heapDelta).toBeLessThan(MAX_HEAP_DELTA_BYTES);
+		expect(memory.rssDelta).toBeLessThan(MAX_RSS_DELTA_BYTES);
+		expect(resourceUsage.maxRSS).toBeLessThan(MAX_PROCESS_RSS_BYTES);
+		expect(memory.uploadedPartCount).toBeGreaterThan(12);
+		expect(memory.uploadedBytes).toBe(memory.initByteLength);
+		expect(memory.uploadedHash).toBe(memory.initSha256);
+		expect(memory.uploadedPrefix).not.toContain(canary);
+		expect(memory.uploadedPrefix).toContain("[REDACTED:aws-access-key-id]");
+		expect(memory.requestPaths[0]).toBe("/rpc/ingest/init");
+		expect(memory.requestPaths).not.toContain("/rpc/ingestSession");
+	}, 120_000);
+
+	test("keeps a 100+ MiB failed R2 init bounded and retryable without legacy fallback", async () => {
+		await isolateCapabilityCache();
+		const directory = await mkdtemp(
+			join(tmpdir(), "opaline-r2-failed-init-large-"),
+		);
+		temporaryDirectories.push(directory);
+		const transcriptPath = join(directory, "failed-init-codex-session.jsonl");
+		const transcriptBytes = await writeCodexTranscriptAtLeast(
+			transcriptPath,
+			"clean",
+			LARGE_TRANSCRIPT_MIN_BYTES,
+		);
+		expect(transcriptBytes).toBeGreaterThan(LARGE_TRANSCRIPT_MIN_BYTES);
+
+		const requestPaths: string[] = [];
+		const server = serveFetchStub({
+			hostname: "127.0.0.1",
+			idleTimeout: 60,
+			port: 0,
+			async fetch(request) {
+				const pathname = new URL(request.url).pathname;
+				requestPaths.push(pathname);
+				if (pathname === "/rpc/ingest/init") {
+					return Response.json(
+						{
+							json: {
+								code: "SERVICE_UNAVAILABLE",
+								defined: false,
+								message: "R2 initialization temporarily unavailable",
+								status: 503,
+							},
+						},
+						{ status: 503 },
+					);
+				}
+				const input = await readRpcInput(request);
+				return rpcResponse({
+					sessionId: getRequiredString(input, "sessionId"),
+					success: true,
+					upgradeHint: { protocol: "r2_multipart_v1" },
+				});
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+		const warmup = await uploadSession(
+			createRequest("failed-init-r2-warmup", "clean"),
+			config,
+		);
+		expect(warmup.success).toBe(true);
+		requestPaths.length = 0;
+
+		const probePath = join(
+			import.meta.dir,
+			"helpers",
+			"r2-upload-memory-probe.ts",
+		);
+		const probe = Bun.spawn(
+			[
+				"bun",
+				probePath,
+				transcriptPath,
+				config.endpoint,
+				TOKEN,
+				"failed-init-codex-session",
+			],
+			{
+				env: { ...process.env, OPALINE_R2_PROBE_MODE: "failed-init" },
+				stderr: "pipe",
+				stdout: "pipe",
+			},
+		);
+		const [exitCode, stdout, stderr] = await Promise.all([
+			probe.exited,
+			new Response(probe.stdout).text(),
+			new Response(probe.stderr).text(),
+		]);
+		const resourceUsage = probe.resourceUsage();
+		const memory = parseMemoryProbe(stdout);
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBe("");
+		expect(memory).toMatchObject({
+			attempts: 3,
+			retryable: true,
+			success: false,
+		});
+		expect(memory.error).toContain("Could not initialize direct R2 upload");
+		expect(memory.heapDelta).toBeLessThan(MAX_HEAP_DELTA_BYTES);
+		expect(memory.rssDelta).toBeLessThan(MAX_FAILED_INIT_RSS_DELTA_BYTES);
+		expect(resourceUsage.maxRSS).toBeLessThan(
+			MAX_FAILED_INIT_PROCESS_RSS_BYTES,
+		);
+		expect(memory.requestPaths).toEqual([
+			"/rpc/ingest/init",
+			"/rpc/ingest/init",
+			"/rpc/ingest/init",
+		]);
+		expect(memory.requestPaths).not.toContain("/rpc/ingestSession");
+		expect(
+			hasAdvertisedR2UploadCapability(
+				new URL(config.endpoint),
+				"api-key",
+				TOKEN,
+			),
+		).toBe(true);
+	}, 120_000);
+
+	test("rejects an empty main transcript locally before any R2 request", async () => {
+		await isolateCapabilityCache();
+		let requestCount = 0;
+		const server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch() {
+				requestCount += 1;
+				return new Response("unexpected request", { status: 500 });
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+		await rememberR2UploadCapability(
+			new URL(config.endpoint),
+			"api-key",
+			TOKEN,
+		);
+
+		const result = await uploadSession(createRequest("empty-main", ""), config);
+
+		expect(result).toEqual({
+			success: false,
+			error: "The main session transcript is empty. Nothing was uploaded.",
+			attempts: 0,
+			retryable: false,
+		});
+		expect(requestCount).toBe(0);
+	});
+
+	test("rejects a file-backed transcript above the safe legacy materialization cap", async () => {
+		await isolateCapabilityCache();
+		const directory = await mkdtemp(join(tmpdir(), "opaline-r2-legacy-cap-"));
+		temporaryDirectories.push(directory);
+		const transcriptPath = join(directory, "legacy-too-large.jsonl");
+		await writeCodexTranscriptAtLeast(
+			transcriptPath,
+			"clean",
+			LEGACY_CAP_TEST_MIN_BYTES,
+		);
+		const requestPaths: string[] = [];
+		const server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			fetch(request) {
+				requestPaths.push(new URL(request.url).pathname);
+				return Response.json(
+					{
+						json: {
+							code: "NOT_FOUND",
+							defined: false,
+							message: "Not Found",
+							status: 404,
+						},
+					},
+					{ status: 404 },
+				);
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+		await rememberR2UploadCapability(
+			new URL(config.endpoint),
+			"api-key",
+			TOKEN,
+		);
+
+		const result = await uploadSession(
+			createFileRequest("legacy-too-large", transcriptPath),
+			config,
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			attempts: 0,
+			retryable: false,
+		});
+		expect(result.error).toContain("Transcript too large for this server");
+		expect(result.error).toContain("32.00 MiB safe limit for legacy uploads");
+		expect(requestPaths).toEqual(["/rpc/ingest/init"]);
+		expect(
+			hasAdvertisedR2UploadCapability(
+				new URL(config.endpoint),
+				"api-key",
+				TOKEN,
+			),
+		).toBe(false);
+	}, 60_000);
+
+	test("keeps using the unchanged legacy body path without an upgrade hint", async () => {
+		await isolateCapabilityCache();
+		const paths: string[] = [];
+		const bodies: string[] = [];
+		const server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				paths.push(new URL(request.url).pathname);
+				bodies.push(await request.text());
+				return rpcResponse({ success: true, sessionId: "legacy-session" });
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+
+		const first = await uploadSession(
+			createRequest("legacy-one", "one"),
+			config,
+		);
+		const second = await uploadSession(
+			createRequest("legacy-two", "two"),
+			config,
+		);
+
+		expect(first.success).toBe(true);
+		expect(second.success).toBe(true);
+		expect(paths).toEqual(["/rpc/ingestSession", "/rpc/ingestSession"]);
+		expect(bodies[0]).toContain('"content":"one"');
+		expect(bodies[1]).toContain('"content":"two"');
+	});
+
+	test("falls back to legacy when an advertised init path is unavailable", async () => {
+		await isolateCapabilityCache();
+		const paths: string[] = [];
+		let legacyCalls = 0;
+		const server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				const pathname = new URL(request.url).pathname;
+				paths.push(pathname);
+				const input = await readRpcInput(request);
+				if (pathname === "/rpc/ingest/init") {
+					return Response.json(
+						{
+							json: {
+								code: "NOT_FOUND",
+								defined: false,
+								message: "Not Found",
+								status: 404,
+							},
+						},
+						{ status: 404 },
+					);
+				}
+				legacyCalls += 1;
+				return rpcResponse({
+					success: true,
+					sessionId: getRequiredString(input, "sessionId"),
+					...(legacyCalls === 1
+						? { upgradeHint: { protocol: "r2_multipart_v1" } }
+						: {}),
+				});
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+
+		const advertised = await uploadSession(
+			createRequest("advertised", "clean"),
+			config,
+		);
+		const fallback = await uploadSession(
+			createRequest("fallback", "still clean"),
+			config,
+		);
+
+		expect(advertised.success).toBe(true);
+		expect(fallback.success).toBe(true);
+		expect(paths).toEqual([
+			"/rpc/ingestSession",
+			"/rpc/ingest/init",
+			"/rpc/ingestSession",
+		]);
+	});
+});
+
+interface FetchStub {
+	readonly port: number;
+	stop(force?: boolean): void;
+}
+
+let nextFetchStubPort = 20_000;
+
+function serveFetchStub(options: {
+	readonly fetch: (request: Request) => Promise<Response> | Response;
+	readonly hostname?: string;
+	readonly idleTimeout?: number;
+	readonly port: number;
+}): FetchStub {
+	const previousFetch = globalThis.fetch;
+	let stopped = false;
+	globalThis.fetch = async (input, init) =>
+		options.fetch(new Request(input, init));
+	return {
+		port: nextFetchStubPort++,
+		stop() {
+			if (stopped) return;
+			stopped = true;
+			globalThis.fetch = previousFetch;
+		},
+	};
+}
+
+async function isolateCapabilityCache(): Promise<void> {
+	const directory = await mkdtemp(join(tmpdir(), "opaline-r2-capabilities-"));
+	temporaryDirectories.push(directory);
+	process.env.OPALINE_CONFIG_DIR = directory;
+}
+
+function createUploadConfig(server: FetchStub): UploadConfig {
+	return {
+		allowInsecureEndpoint: false,
+		authType: "api-key",
+		endpoint: `http://127.0.0.1:${server.port}/rpc`,
+		r2MultipartBaseDelayMs: 0,
+		r2StatusPollIntervalMs: 0,
+		token: TOKEN,
+	};
+}
+
+function createRequest(sessionId: string, content: string): IngestSessionInput {
+	return {
+		content,
+		projectPath: "/test/project",
+		sessionId,
+		source: "claude_code",
+	};
+}
+
+function createFileRequest(
+	sessionId: string,
+	transcriptPath: string,
+): FileBackedUploadRequest {
+	return {
+		kind: "file",
+		metadata: {
+			projectPath: "/test/project",
+			sessionId,
+			source: "codex",
+		},
+		subagents: [],
+		transcriptPath,
+	};
+}
+
+function createSuccessResult(sessionId: string) {
+	return {
+		redacted: {},
+		redactedBytes: 0,
+		sessionId,
+		success: true,
+	};
+}
+
+function rpcResponse(value: unknown): Response {
+	return Response.json({ json: value });
+}
+
+async function readRpcInput(
+	request: Request,
+): Promise<Record<string, unknown>> {
+	const parsed: unknown = JSON.parse(await request.text());
+	if (!isRecord(parsed) || !isRecord(parsed.json)) {
+		throw new Error("invalid oRPC test request");
+	}
+	return parsed.json;
+}
+
+function getMainObject(
+	input: Record<string, unknown>,
+): Record<string, unknown> {
+	if (!Array.isArray(input.objects)) throw new Error("missing R2 objects");
+	const main = input.objects.find(
+		(object) => isRecord(object) && object.kind === "main",
+	);
+	if (!isRecord(main)) throw new Error("missing R2 main object");
+	return main;
+}
+
+function getRequiredMapValue(
+	values: ReadonlyMap<string, Record<string, unknown>>,
+	key: string,
+): Record<string, unknown> {
+	const value = values.get(key);
+	if (!value) throw new Error(`missing captured RPC input for ${key}`);
+	return value;
+}
+
+function getRequiredString(
+	record: Record<string, unknown>,
+	key: string,
+): string {
+	const value = record[key];
+	if (typeof value !== "string") throw new Error(`missing string ${key}`);
+	return value;
+}
+
+function getRequiredNumber(
+	record: Record<string, unknown>,
+	key: string,
+): number {
+	const value = record[key];
+	if (typeof value !== "number") throw new Error(`missing number ${key}`);
+	return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+async function writeCodexTranscriptAtLeast(
+	path: string,
+	canary: string,
+	minimumBytes: number,
+): Promise<number> {
+	const file = await open(path, "wx", 0o600);
+	try {
+		const firstRecord = Buffer.from(
+			`${JSON.stringify({
+				message: `Use ${canary}`,
+				padding: "x".repeat(200),
+				timestamp: "2026-08-25T12:00:00.000Z",
+				type: "event_msg",
+			})}\n`,
+		);
+		const paddingRecord = Buffer.from(
+			`${JSON.stringify({
+				message: "x".repeat(64 * 1024 - 200),
+				timestamp: "2026-08-25T12:00:01.000Z",
+				type: "response_item",
+			})}\n`,
+		);
+		let byteLength = await writeCompleteBuffer(file, firstRecord);
+		while (byteLength <= minimumBytes) {
+			byteLength += await writeCompleteBuffer(file, paddingRecord);
+		}
+	} finally {
+		await file.close();
+	}
+	return (await stat(path)).size;
+}
+
+async function writeCompleteBuffer(
+	file: FileHandle,
+	buffer: Uint8Array,
+): Promise<number> {
+	let offset = 0;
+	while (offset < buffer.byteLength) {
+		const { bytesWritten } = await file.write(
+			buffer,
+			offset,
+			buffer.byteLength - offset,
+		);
+		if (bytesWritten === 0) throw new Error("Large fixture write stalled");
+		offset += bytesWritten;
+	}
+	return offset;
+}
+
+function parseMemoryProbe(raw: string): MemoryProbe {
+	const value: unknown = JSON.parse(raw);
+	if (
+		!isRecord(value) ||
+		typeof value.attempts !== "number" ||
+		typeof value.awsRedactions !== "number" ||
+		(value.error !== null && typeof value.error !== "string") ||
+		typeof value.heapDelta !== "number" ||
+		typeof value.initByteLength !== "number" ||
+		typeof value.initSha256 !== "string" ||
+		!Array.isArray(value.requestPaths) ||
+		!value.requestPaths.every((path) => typeof path === "string") ||
+		(value.retryable !== null && typeof value.retryable !== "boolean") ||
+		typeof value.rssDelta !== "number" ||
+		typeof value.success !== "boolean" ||
+		typeof value.uploadedBytes !== "number" ||
+		typeof value.uploadedHash !== "string" ||
+		typeof value.uploadedPartCount !== "number" ||
+		typeof value.uploadedPrefix !== "string"
+	) {
+		throw new Error(`Invalid memory probe output: ${raw}`);
+	}
+	return {
+		attempts: value.attempts,
+		awsRedactions: value.awsRedactions,
+		error: value.error,
+		heapDelta: value.heapDelta,
+		initByteLength: value.initByteLength,
+		initSha256: value.initSha256,
+		requestPaths: value.requestPaths,
+		retryable: value.retryable,
+		rssDelta: value.rssDelta,
+		success: value.success,
+		uploadedBytes: value.uploadedBytes,
+		uploadedHash: value.uploadedHash,
+		uploadedPartCount: value.uploadedPartCount,
+		uploadedPrefix: value.uploadedPrefix,
+	};
+}

--- a/apps/cli/src/__tests__/upload-reconciliation.test.ts
+++ b/apps/cli/src/__tests__/upload-reconciliation.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { resolveRepoIdentity, type Source } from "../contracts/index.js";
+import type { ScannedProject } from "../internal/agent-adapters/index.js";
+import {
+	classifyUploadProjects,
+	getRepositoryHookState,
+	groupUploadProjectsByRepository,
+	orderUploadRepositoriesNewFirst,
+	type ResolvedOrganizationUploadStatus,
+} from "../lib/upload-reconciliation.js";
+
+describe("upload reconciliation", () => {
+	test("classifies remote uploads and suppresses local duplicates per resolved organization", () => {
+		const firstProject = createProject("first", ["uploaded", "shared-new"]);
+		const secondProject = createProject("second", ["shared-new", "other-new"]);
+		const thirdProject = createProject("third", ["shared-new"]);
+		const statuses = new Map<
+			string | undefined,
+			ResolvedOrganizationUploadStatus
+		>([
+			[
+				undefined,
+				{
+					organizationId: "org-a",
+					uploadedSessionIds: new Set(["uploaded"]),
+				},
+			],
+			[
+				"org-a",
+				{
+					organizationId: "org-a",
+					uploadedSessionIds: new Set(["uploaded"]),
+				},
+			],
+			[
+				"org-b",
+				{
+					organizationId: "org-b",
+					uploadedSessionIds: new Set(),
+				},
+			],
+		]);
+
+		const result = classifyUploadProjects(
+			[
+				{ organizationId: undefined, project: firstProject },
+				{ organizationId: "org-a", project: secondProject },
+				{ organizationId: "org-b", project: thirdProject },
+			],
+			statuses,
+		);
+
+		expect(
+			result[0]?.uploadedSessions.map((session) => session.sessionId),
+		).toEqual(["uploaded"]);
+		expect(result[0]?.newSessions.map((session) => session.sessionId)).toEqual([
+			"shared-new",
+		]);
+		expect(
+			result[1]?.duplicateSessions.map((session) => session.sessionId),
+		).toEqual(["shared-new"]);
+		expect(result[1]?.newSessions.map((session) => session.sessionId)).toEqual([
+			"other-new",
+		]);
+		expect(result[2]?.newSessions.map((session) => session.sessionId)).toEqual([
+			"shared-new",
+		]);
+	});
+
+	test("groups worktrees and agent sources into canonical repositories", () => {
+		const uploadedWorktree = createProject("podgorica", ["old"], {
+			projectPath:
+				"/Users/test/conductor/workspaces/rudel-v2/podgorica/apps/cli",
+			source: "claude_code",
+		});
+		const newWorktree = createProject("lansing", ["new"], {
+			projectPath: "/Users/test/conductor/workspaces/rudel-v2/lansing",
+			source: "codex",
+		});
+		const currentProject = createProject("other", ["uploaded"], {
+			projectPath: "/Users/test/projects/other",
+			source: "claude_code",
+		});
+		const projects = [
+			{
+				newSessions: [],
+				project: uploadedWorktree,
+				hookInstalled: true,
+				repositoryIdentity: resolveIdentity(uploadedWorktree),
+			},
+			{
+				newSessions: newWorktree.sessions,
+				project: newWorktree,
+				hookInstalled: false,
+				repositoryIdentity: resolveIdentity(newWorktree),
+			},
+			{
+				newSessions: [],
+				project: currentProject,
+				hookInstalled: true,
+				repositoryIdentity: resolveRepoIdentity({
+					gitRemote: "github.com/acme/other",
+					packageName: null,
+					projectPath: currentProject.projectPath,
+				}),
+			},
+		];
+		const order = new Map([
+			[uploadedWorktree, { containsCwd: false, index: 1 }],
+			[newWorktree, { containsCwd: false, index: 2 }],
+			[currentProject, { containsCwd: true, index: 0 }],
+		]);
+
+		const repositories = groupUploadProjectsByRepository(projects);
+		const rudelRepository = repositories.find(
+			(repository) => repository.key === "path:rudel-v2",
+		);
+		if (!rudelRepository)
+			throw new Error("rudel-v2 repository was not grouped");
+		const result = orderUploadRepositoriesNewFirst(repositories, order);
+
+		expect(repositories).toHaveLength(2);
+		expect(rudelRepository.label).toBe("rudel-v2");
+		expect(
+			rudelRepository.projects.map((project) => project.project.displayPath),
+		).toEqual(["podgorica", "lansing"]);
+		expect(getRepositoryHookState(rudelRepository)).toBe("mixed");
+		expect(result.map((repository) => repository.label)).toEqual([
+			"rudel-v2",
+			"acme/other",
+		]);
+	});
+});
+
+function createProject(
+	name: string,
+	sessionIds: readonly string[],
+	options: {
+		readonly projectPath?: string;
+		readonly source?: Source;
+	} = {},
+): ScannedProject {
+	const projectPath = options.projectPath ?? `/test/${name}`;
+	const sessions = sessionIds.map((sessionId) => ({
+		projectPath,
+		sessionId,
+		transcriptPath: `${projectPath}/${sessionId}.jsonl`,
+	}));
+	return {
+		displayPath: name,
+		projectPath,
+		sessionCount: sessions.length,
+		sessions,
+		source: options.source ?? "claude_code",
+	};
+}
+
+function resolveIdentity(project: ScannedProject) {
+	return resolveRepoIdentity({
+		gitRemote: null,
+		packageName: null,
+		projectPath: project.projectPath,
+	});
+}

--- a/apps/cli/src/__tests__/upload.integration.test.ts
+++ b/apps/cli/src/__tests__/upload.integration.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, readdirSync } from "node:fs";
 import {
+	type FileHandle,
 	mkdir,
 	mkdtemp,
+	open,
 	readdir,
 	rm,
 	symlink,
@@ -17,6 +19,7 @@ import {
 	readFileWithRetry,
 	readSubagentFiles,
 } from "../internal/agent-adapters/index.js";
+import { MAX_STREAM_RECORD_BYTES } from "../lib/filtered-upload-staging.js";
 import { getGitInfo } from "../lib/git-info.js";
 import { resolveSession } from "../lib/session-resolver.js";
 
@@ -293,7 +296,123 @@ describe("subagent reader", () => {
 			expect(subagents).toEqual([]);
 		},
 	);
+});
 
+describe("file-backed transcript scanning", () => {
+	test("parses a Codex record just under the staging byte cap", async () => {
+		const sessionId = "large-valid-codex-record";
+		const sessionFile = join(tempDir, `${sessionId}.jsonl`);
+		const emptyRecord = JSON.stringify({
+			padding: "",
+			timestamp: "2026-07-29T10:00:00.000Z",
+			type: "event_msg",
+		});
+		const targetBytes = MAX_STREAM_RECORD_BYTES - 1;
+		const paddingBytes = targetBytes - Buffer.byteLength(emptyRecord) - 1;
+		const record = `${JSON.stringify({
+			padding: "x".repeat(paddingBytes),
+			timestamp: "2026-07-29T10:00:00.000Z",
+			type: "event_msg",
+		})}\n`;
+		expect(Buffer.byteLength(record)).toBe(targetBytes);
+		await writeFile(sessionFile, record);
+
+		const request = await codexAdapter.buildUploadRequest(
+			{
+				projectPath: tempDir,
+				sessionId,
+				transcriptPath: sessionFile,
+			},
+			{ gitInfo: {}, uploadMode: "manual" },
+		);
+
+		expect(request.transcriptPath).toBe(sessionFile);
+	});
+
+	test("collects Claude subagent IDs around an oversized record", async () => {
+		const sessionId = "claude-oversized-record";
+		const sessionFile = join(tempDir, `${sessionId}.jsonl`);
+		const file = await open(sessionFile, "wx", 0o600);
+		try {
+			await writeCompleteBuffer(
+				file,
+				Buffer.from(
+					`${JSON.stringify({
+						timestamp: "2026-07-29T10:00:00.000Z",
+						type: "user",
+					})}\n${JSON.stringify({ toolUseResult: { agentId: "before" } })}\n`,
+				),
+			);
+			await writeCompleteBuffer(
+				file,
+				Buffer.from('{"type":"tool_result","content":"'),
+			);
+			await writeCompleteBuffer(
+				file,
+				Buffer.alloc(MAX_STREAM_RECORD_BYTES, "x"),
+			);
+			await writeCompleteBuffer(file, Buffer.from('"}\n'));
+			await writeCompleteBuffer(
+				file,
+				Buffer.from(
+					`${JSON.stringify({ toolUseResult: { agentId: "after" } })}\n`,
+				),
+			);
+		} finally {
+			await file.close();
+		}
+		await Promise.all([
+			writeFile(join(tempDir, "agent-before.jsonl"), "{}"),
+			writeFile(join(tempDir, "agent-after.jsonl"), "{}"),
+		]);
+
+		const request = await claudeCodeAdapter.buildUploadRequest(
+			{
+				projectPath: tempDir,
+				sessionId,
+				transcriptPath: sessionFile,
+			},
+			{ gitInfo: {}, uploadMode: "manual" },
+		);
+
+		expect(request.subagents.map((subagent) => subagent.agentId)).toEqual([
+			"before",
+			"after",
+		]);
+	});
+
+	test("retries opening a Claude transcript that appears after the first attempt", async () => {
+		const sessionId = "claude-delayed-transcript";
+		const sessionFile = join(tempDir, `${sessionId}.jsonl`);
+		const writeTranscript = new Promise<void>((resolve, reject) => {
+			setTimeout(() => {
+				writeFile(
+					sessionFile,
+					JSON.stringify({
+						timestamp: "2026-07-29T10:00:00.000Z",
+						type: "user",
+					}),
+				).then(() => resolve(), reject);
+			}, 100);
+		});
+		const startedAt = Date.now();
+
+		const request = await claudeCodeAdapter.buildUploadRequest(
+			{
+				projectPath: tempDir,
+				sessionId,
+				transcriptPath: sessionFile,
+			},
+			{ gitInfo: {}, uploadMode: "manual" },
+		);
+		await writeTranscript;
+
+		expect(request.transcriptPath).toBe(sessionFile);
+		expect(Date.now() - startedAt).toBeGreaterThanOrEqual(450);
+	});
+});
+
+describe("subagent reader", () => {
 	test.skipIf(process.platform === "win32")(
 		"does not follow a subagents directory symlink outside the session directory",
 		async () => {
@@ -319,6 +438,22 @@ describe("subagent reader", () => {
 		},
 	);
 });
+
+async function writeCompleteBuffer(
+	file: FileHandle,
+	buffer: Uint8Array,
+): Promise<void> {
+	let offset = 0;
+	while (offset < buffer.byteLength) {
+		const { bytesWritten } = await file.write(
+			buffer,
+			offset,
+			buffer.byteLength - offset,
+		);
+		if (bytesWritten === 0) throw new Error("Fixture write stalled");
+		offset += bytesWritten;
+	}
+}
 
 describe("git info", () => {
 	test("extracts git info from current repo", async () => {

--- a/apps/cli/src/__tests__/upload.integration.test.ts
+++ b/apps/cli/src/__tests__/upload.integration.test.ts
@@ -8,7 +8,7 @@ import {
 	symlink,
 	writeFile,
 } from "node:fs/promises";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
 	claudeCodeAdapter,
@@ -82,7 +82,7 @@ const hasClaudeProjects = hasRealClaudeSessions();
 let tempDir: string;
 
 beforeAll(async () => {
-	tempDir = await mkdtemp(join(homedir(), ".rudel-cli-test-"));
+	tempDir = await mkdtemp(join(tmpdir(), "opaline-cli-test-"));
 });
 
 afterAll(async () => {
@@ -373,6 +373,43 @@ describe("full upload pipeline (dry-run)", () => {
 		},
 	);
 
+	test.each([
+		{
+			adapter: claudeCodeAdapter,
+			content: SAMPLE_SESSION_CONTENT,
+			name: "Claude Code",
+		},
+		{
+			adapter: codexAdapter,
+			content: `${JSON.stringify({
+				timestamp: "2026-07-29T10:00:00.000Z",
+				type: "event_msg",
+			})}\n`,
+			name: "Codex",
+		},
+	])(
+		"builds a file-backed $name upload request",
+		async ({ adapter, content }) => {
+			const sessionId = `file-backed-${adapter.source}`;
+			const sessionFile = join(tempDir, `${sessionId}.jsonl`);
+			await writeFile(sessionFile, content);
+
+			const request = await adapter.buildUploadRequest(
+				{
+					projectPath: tempDir,
+					sessionId,
+					transcriptPath: sessionFile,
+				},
+				{ gitInfo: {}, uploadMode: "manual" },
+			);
+
+			expect(request.kind).toBe("file");
+			expect(request.transcriptPath).toBe(sessionFile);
+			expect(request.metadata.sessionId).toBe(sessionId);
+			expect("content" in request).toBe(false);
+		},
+	);
+
 	test("resolves session by path, reads transcript, extracts subagents, and builds request", async () => {
 		// Set up a realistic session directory
 		const projectDir = join(tempDir, "pipeline-test");
@@ -431,14 +468,21 @@ describe("full upload pipeline (dry-run)", () => {
 			const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
 			const proc = Bun.spawn(
 				["bun", cliPath, "upload", realSessionId, "--dry-run"],
-				{ stdout: "pipe", stderr: "pipe" },
+				{
+					env: {
+						...process.env,
+						OPALINE_CONFIG_DIR: join(tempDir, "config"),
+					},
+					stdout: "pipe",
+					stderr: "pipe",
+				},
 			);
 
 			const exitCode = await proc.exited;
 			const stdout = await new Response(proc.stdout).text();
 			const stderr = await new Response(proc.stderr).text();
 
-			expect(exitCode).toBe(0);
+			expect(exitCode, stderr).toBe(0);
 			expect(stdout).toContain("Resolving session:");
 			expect(stdout).toContain("Found session at:");
 			expect(stdout).toContain("Dry run - would upload:");
@@ -463,13 +507,21 @@ describe("full upload pipeline (dry-run)", () => {
 		const cliPath = join(import.meta.dir, "..", "bin", "cli.ts");
 		const proc = Bun.spawn(
 			["bun", cliPath, "upload", sessionFile, "--dry-run"],
-			{ stdout: "pipe", stderr: "pipe" },
+			{
+				env: {
+					...process.env,
+					OPALINE_CONFIG_DIR: join(tempDir, "config"),
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			},
 		);
 
 		const exitCode = await proc.exited;
 		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
 
-		expect(exitCode).toBe(0);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Found session at:");
 		expect(stdout).toContain("Subagents: 1 file(s)");
 		expect(stdout).toContain("Dry run - would upload:");

--- a/apps/cli/src/commands/disable.ts
+++ b/apps/cli/src/commands/disable.ts
@@ -1,8 +1,10 @@
 import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { getAllAdapters } from "../internal/agent-adapters/index.js";
+import { clearAutoUploadRepositories } from "../lib/auto-upload-config.js";
 
 async function runDisable(): Promise<void> {
+	clearAutoUploadRepositories();
 	const adapters = getAllAdapters();
 	let anyDisabled = false;
 

--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -7,6 +7,7 @@ import {
 } from "../internal/agent-adapters/index.js";
 import { describeSavedCredentialsApiBaseRisk } from "../lib/api-base.js";
 import { createApiClient } from "../lib/api-client.js";
+import { PRODUCTION_API_BASE } from "../lib/api-target.js";
 import { verifyAuth } from "../lib/auth.js";
 import { enableAutoUploadRepository } from "../lib/auto-upload-config.js";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
@@ -99,7 +100,7 @@ async function runEnable(): Promise<undefined | Error> {
 			error: new Error("No organizations found"),
 			userId: auth.user.id,
 		});
-		p.outro("Create one at app.opaline.ai first.");
+		p.outro(`Create one at ${PRODUCTION_API_BASE} first.`);
 		return new Error("No organizations found.");
 	}
 

--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -1,6 +1,6 @@
 import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
-import type { Source } from "../contracts/index.js";
+import { resolveRepoIdentity, type Source } from "../contracts/index.js";
 import {
 	type AgentAdapter,
 	getAvailableAdapters,
@@ -8,6 +8,7 @@ import {
 import { describeSavedCredentialsApiBaseRisk } from "../lib/api-base.js";
 import { createApiClient } from "../lib/api-client.js";
 import { verifyAuth } from "../lib/auth.js";
+import { enableAutoUploadRepository } from "../lib/auto-upload-config.js";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
 import { getGitInfo } from "../lib/git-info.js";
@@ -98,7 +99,7 @@ async function runEnable(): Promise<undefined | Error> {
 			error: new Error("No organizations found"),
 			userId: auth.user.id,
 		});
-		p.outro("Create one at app.rudel.ai first.");
+		p.outro("Create one at app.opaline.ai first.");
 		return new Error("No organizations found.");
 	}
 
@@ -168,6 +169,17 @@ async function runEnable(): Promise<undefined | Error> {
 	} else {
 		adaptersToEnable = adapters;
 	}
+	const gitInfo = await getGitInfo(cwd);
+	const repository = resolveRepoIdentity({
+		gitRemote: gitInfo.gitRemote ?? null,
+		packageName: gitInfo.packageName ?? null,
+		projectPath: cwd,
+	});
+	enableAutoUploadRepository({
+		key: repository.repoKey,
+		label: repository.repoLabel,
+		sources: adaptersToEnable.map((adapter) => adapter.source),
+	});
 
 	for (const adapter of adaptersToEnable) {
 		const isAlreadyEnabled = adapter.isHookInstalled();
@@ -227,8 +239,6 @@ async function runEnable(): Promise<undefined | Error> {
 		});
 
 		if (p.isCancel(shouldUpload) || !shouldUpload) continue;
-
-		const gitInfo = await getGitInfo(cwd);
 
 		const items: BatchUploadItem[] = sessions.map((session) => ({
 			sessionId: session.sessionId,

--- a/apps/cli/src/commands/hooks/claude/session-end.ts
+++ b/apps/cli/src/commands/hooks/claude/session-end.ts
@@ -1,10 +1,12 @@
 import { getLogger } from "@logtape/logtape";
 import { buildCommand } from "@stricli/core";
+import { resolveRepoIdentity } from "../../../contracts/index.js";
 import {
 	claudeCodeAdapter,
 	type SessionFile,
 } from "../../../internal/agent-adapters/index.js";
 import { getApiBaseOverride } from "../../../lib/api-target.js";
+import { isRepositoryAutoUploadAllowed } from "../../../lib/auto-upload-config.js";
 import { loadCredentials } from "../../../lib/credentials.js";
 import { removeFailedUpload } from "../../../lib/failed-uploads.js";
 import { getGitInfo } from "../../../lib/git-info.js";
@@ -41,6 +43,27 @@ async function runSessionEnd(): Promise<undefined | Error> {
 
 		const input = JSON.parse(raw) as HookInput;
 		if (!input.session_id || !input.transcript_path) return;
+		const gitInfo = await getGitInfo(input.cwd);
+		const repository = resolveRepoIdentity({
+			gitRemote: gitInfo.gitRemote ?? null,
+			packageName: gitInfo.packageName ?? null,
+			projectPath: input.cwd,
+		});
+		if (
+			!isRepositoryAutoUploadAllowed(
+				repository.repoKey,
+				claudeCodeAdapter.source,
+			)
+		) {
+			logger.info(
+				"Skipping session {sessionId}: automatic upload is disabled for {repository}",
+				{
+					repository: repository.repoLabel,
+					sessionId: input.session_id,
+				},
+			);
+			return;
+		}
 
 		const credentials = loadCredentials();
 		if (!credentials) {
@@ -60,7 +83,6 @@ async function runSessionEnd(): Promise<undefined | Error> {
 			projectPath: input.cwd,
 		};
 
-		const gitInfo = await getGitInfo(input.cwd);
 		const organizationId = await getProjectOrgId(input.cwd);
 
 		const request = await claudeCodeAdapter.buildUploadRequest(sessionFile, {

--- a/apps/cli/src/commands/hooks/codex/turn-complete.ts
+++ b/apps/cli/src/commands/hooks/codex/turn-complete.ts
@@ -1,11 +1,13 @@
 import { getLogger } from "@logtape/logtape";
 import { buildCommand } from "@stricli/core";
+import { resolveRepoIdentity } from "../../../contracts/index.js";
 import {
 	codexAdapter,
 	findActiveRolloutFile,
 	type SessionFile,
 } from "../../../internal/agent-adapters/index.js";
 import { getApiBaseOverride } from "../../../lib/api-target.js";
+import { isRepositoryAutoUploadAllowed } from "../../../lib/auto-upload-config.js";
 import { loadCredentials } from "../../../lib/credentials.js";
 import { removeFailedUpload } from "../../../lib/failed-uploads.js";
 import { getGitInfo } from "../../../lib/git-info.js";
@@ -51,6 +53,24 @@ async function runTurnComplete(
 
 		const input = parseNotification(notification);
 		if (!input) return;
+		const gitInfo = await getGitInfo(input.cwd);
+		const repository = resolveRepoIdentity({
+			gitRemote: gitInfo.gitRemote ?? null,
+			packageName: gitInfo.packageName ?? null,
+			projectPath: input.cwd,
+		});
+		if (
+			!isRepositoryAutoUploadAllowed(repository.repoKey, codexAdapter.source)
+		) {
+			logger.info(
+				"Skipping session {sessionId}: automatic upload is disabled for {repository}",
+				{
+					repository: repository.repoLabel,
+					sessionId: input.threadId,
+				},
+			);
+			return;
+		}
 
 		const credentials = loadCredentials();
 		if (!credentials) {
@@ -74,7 +94,6 @@ async function runTurnComplete(
 			projectPath: input.cwd,
 		};
 
-		const gitInfo = await getGitInfo(input.cwd);
 		const organizationId = await getProjectOrgId(input.cwd);
 
 		const request = await codexAdapter.buildUploadRequest(sessionFile, {

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -1,23 +1,37 @@
+import { stat } from "node:fs/promises";
 import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
-import type { IngestSessionInput, Source } from "../contracts/index.js";
+import pMap from "p-map";
+import {
+	type RepoIdentity,
+	resolveRepoIdentity,
+	type Source,
+} from "../contracts/index.js";
 import {
 	claudeCodeAdapter,
+	type FileBackedUploadRequest,
 	getAdapter,
+	getAllAdapters,
 	MissingTranscriptTimestampError,
 	type ScannedProject,
 	type SessionFile,
 } from "../internal/agent-adapters/index.js";
+import {
+	type AutoUploadConfig,
+	getRequiredAutoUploadSources,
+	loadAutoUploadConfig,
+	saveVisibleAutoUploadSelections,
+} from "../lib/auto-upload-config.js";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
-import { classifySession } from "../lib/classifier.js";
+import { classifySessionFile } from "../lib/classifier.js";
 import { type Credentials, loadCredentials } from "../lib/credentials.js";
 import {
 	isRetryCandidate,
 	loadFailedUploads,
 	removeFailedUpload,
 } from "../lib/failed-uploads.js";
-import { getGitInfo } from "../lib/git-info.js";
+import { type GitInfo, getGitInfo } from "../lib/git-info.js";
 import { getProjectOrgId } from "../lib/project-config.js";
 import { scanAndGroupProjects } from "../lib/project-grouping.js";
 import { resolveSession } from "../lib/session-resolver.js";
@@ -27,6 +41,14 @@ import {
 	type SessionTag,
 } from "../lib/types.js";
 import { allowsInsecureEndpoint } from "../lib/upload-endpoint.js";
+import {
+	groupUploadProjectsByRepository,
+	orderUploadRepositoriesNewFirst,
+	type ReconciledUploadProject,
+	reconcileUploadProjects,
+	type UploadProjectTarget,
+	type UploadRepositoryGroup,
+} from "../lib/upload-reconciliation.js";
 import {
 	formatRedactionSummary,
 	type UploadConfig,
@@ -50,6 +72,30 @@ interface ResolvedUploadFlags extends UploadFlags {
 	endpoint: string;
 }
 
+interface InteractiveUploadProject extends UploadProjectTarget {
+	readonly duplicateSessions: readonly SessionFile[];
+	readonly gitInfo: GitInfo | undefined;
+	readonly hookInstalled: boolean;
+	readonly newSessions: readonly SessionFile[];
+	readonly repositoryIdentity: RepoIdentity;
+	readonly statusKnown: boolean;
+	readonly uploadedSessions: readonly SessionFile[];
+}
+
+type InteractiveUploadRepository =
+	UploadRepositoryGroup<InteractiveUploadProject>;
+
+interface UploadProjectMetadata {
+	readonly gitInfo: GitInfo | undefined;
+	readonly hookInstalled: boolean;
+	readonly repositoryIdentity: RepoIdentity;
+}
+
+interface PreparedUploadTarget {
+	readonly metadata: UploadProjectMetadata;
+	readonly target: UploadProjectTarget;
+}
+
 async function runInteractiveUpload(
 	flags: ResolvedUploadFlags,
 	allowPlaintextEndpoint: boolean,
@@ -64,68 +110,203 @@ async function runInteractiveUpload(
 		persistRemoteCache: !flags.dryRun,
 	});
 
-	spin.stop(`Found ${allProjects.length} project(s)`);
-
 	if (allProjects.length === 0) {
+		spin.stop("No local sessions found");
 		p.log.warn("No projects with sessions found.");
 		p.outro("Nothing to upload.");
 		return;
 	}
 
-	const options: Array<{
-		value: ScannedProject;
-		label: string;
-		hint: string;
-	}> = [];
-	const preSelected: ScannedProject[] = [];
-
-	for (const group of groups) {
-		for (const proj of group.projects) {
-			options.push({
-				value: proj,
-				label: `[${getAdapterName(proj.source)}] ${proj.displayPath}`,
-				hint: sessionCountHint(proj.sessionCount),
+	const preparedTargets = await pMap(
+		allProjects,
+		(project) => prepareUploadTarget(project, flags.org),
+		{ concurrency: 10 },
+	);
+	const targets = preparedTargets.map((prepared) => prepared.target);
+	const metadataByProject = new Map<ScannedProject, UploadProjectMetadata>();
+	for (const prepared of preparedTargets) {
+		metadataByProject.set(prepared.target.project, prepared.metadata);
+	}
+	let uploadProjects: InteractiveUploadProject[];
+	if (credentials) {
+		spin.message("Checking which sessions are already uploaded...");
+		let reconciled: ReconciledUploadProject[];
+		try {
+			reconciled = await reconcileUploadProjects(targets, {
+				allowInsecureEndpoint: allowPlaintextEndpoint,
+				authType: credentials.authType,
+				endpoint: flags.endpoint,
+				token: credentials.token,
 			});
-			if (group.containsCwd) {
-				preSelected.push(proj);
-			}
+		} catch (error) {
+			spin.stop("Could not check uploaded sessions");
+			return error instanceof Error ? error : new Error(String(error));
 		}
+		uploadProjects = reconciled.map((project) => ({
+			...project,
+			...getUploadProjectMetadata(metadataByProject, project.project),
+			statusKnown: true,
+		}));
+	} else {
+		uploadProjects = targets.map((target) => ({
+			...target,
+			...getUploadProjectMetadata(metadataByProject, target.project),
+			duplicateSessions: [],
+			newSessions: target.project.sessions,
+			statusKnown: false,
+			uploadedSessions: [],
+		}));
+	}
+
+	const totalLocalSessions = allProjects.reduce(
+		(sum, project) => sum + project.sessionCount,
+		0,
+	);
+	const totalNewSessions = uploadProjects.reduce(
+		(sum, project) => sum + project.newSessions.length,
+		0,
+	);
+	const totalUploadedSessions = uploadProjects.reduce(
+		(sum, project) => sum + project.uploadedSessions.length,
+		0,
+	);
+	const totalDuplicateSessions = uploadProjects.reduce(
+		(sum, project) => sum + project.duplicateSessions.length,
+		0,
+	);
+	spin.stop(
+		credentials
+			? `${totalNewSessions} new · ${totalUploadedSessions} already uploaded${
+					totalDuplicateSessions > 0
+						? ` · ${totalDuplicateSessions} local duplicate`
+						: ""
+				}`
+			: `Found ${totalLocalSessions} local session(s)`,
+	);
+
+	const options: Array<{
+		value: string;
+		label: string;
+	}> = [];
+	const preSelected: string[] = [];
+	const projectOrder = new Map<
+		ScannedProject,
+		{ readonly containsCwd: boolean; readonly index: number }
+	>();
+	let projectIndex = 0;
+	for (const group of groups) {
+		for (const project of group.projects) {
+			projectOrder.set(project, {
+				containsCwd: group.containsCwd,
+				index: projectIndex,
+			});
+			projectIndex++;
+		}
+	}
+	const autoUploadConfig = loadAutoUploadConfig();
+	const repositories = groupUploadProjectsByRepository(uploadProjects);
+	const orderedRepositories = orderUploadRepositoriesNewFirst(
+		repositories,
+		projectOrder,
+	);
+
+	for (const repository of orderedRepositories) {
+		const autoUploadSelected = isRepositoryAutoUploadSelected(
+			repository,
+			autoUploadConfig,
+		);
+		options.push({
+			value: repository.key,
+			label: `${repository.label} (${getRepositoryUploadHint(repository)} · ${getRepositoryAutoUploadHint(repository, autoUploadSelected, autoUploadConfig)})`,
+		});
+		if (autoUploadSelected) preSelected.push(repository.key);
 	}
 
 	const selected = await p.multiselect({
-		message: "Select projects to upload",
+		message: "Choose repositories for automatic upload",
 		options,
 		initialValues: preSelected,
-		required: true,
+		required: false,
 	});
 
 	if (p.isCancel(selected)) {
 		p.cancel("Upload cancelled.");
 		return;
 	}
+	const selectedRepoKeys = new Set(selected);
+	const selectedRepositories = orderedRepositories.filter((repository) =>
+		selectedRepoKeys.has(repository.key),
+	);
 
-	const totalSessions = selected.reduce(
-		(sum, proj) => sum + proj.sessionCount,
+	const totalSessions = selectedRepositories.reduce(
+		(sum, repository) =>
+			sum +
+			getRepositorySessionsToUpload(repository, flags.forceReplace).length,
+		0,
+	);
+	const skippedUploadedSessions = flags.forceReplace
+		? 0
+		: selectedRepositories.reduce(
+				(sum, repository) =>
+					sum + getRepositoryUploadedSessionCount(repository),
+				0,
+			);
+	const skippedDuplicateSessions = selectedRepositories.reduce(
+		(sum, repository) => sum + getRepositoryDuplicateSessionCount(repository),
 		0,
 	);
 
 	if (flags.dryRun) {
-		for (const project of selected) {
+		logAutoUploadSelectionPreview(
+			orderedRepositories,
+			selectedRepoKeys,
+			autoUploadConfig,
+		);
+		for (const repository of selectedRepositories) {
+			const count = getRepositorySessionsToUpload(
+				repository,
+				flags.forceReplace,
+			).length;
+			if (count === 0) continue;
 			p.log.info(
-				`Would upload ${sessionCountHint(project.sessionCount)} from [${getAdapterName(project.source)}] ${project.displayPath}`,
+				`Would upload ${sessionCountHint(count)} from ${repository.label}`,
 			);
 		}
-		p.outro("Dry run complete — no sessions were uploaded.");
+		logSkippedSessions(skippedUploadedSessions, skippedDuplicateSessions);
+		p.outro("Dry run complete — no settings changed and no sessions uploaded.");
 		return;
 	}
 
 	if (!credentials) {
 		return new Error("Not authenticated. Run `opaline login` first.");
 	}
-
-	p.log.info(
-		`Uploading ${totalSessions} session(s) from ${selected.length} project(s)`,
+	const savedAutoUploadConfig = saveVisibleAutoUploadSelections(
+		orderedRepositories.map(toAutoUploadRepositorySelection),
+		selectedRepoKeys,
 	);
+	const hookFailures = reconcileAutoUploadHooks(savedAutoUploadConfig);
+
+	const uploadingRepositoryCount = selectedRepositories.filter(
+		(repository) =>
+			getRepositorySessionsToUpload(repository, flags.forceReplace).length > 0,
+	).length;
+	if (totalSessions > 0) {
+		p.log.info(
+			`Uploading ${totalSessions} session(s) from ${uploadingRepositoryCount} ${repositoryCountHint(uploadingRepositoryCount)}`,
+		);
+	} else if (selectedRepositories.length === 0) {
+		p.log.info("Automatic upload is off for all visible repositories.");
+	} else {
+		p.log.info("No new sessions in the selected repositories.");
+	}
+	logSkippedSessions(skippedUploadedSessions, skippedDuplicateSessions);
+	if (totalSessions === 0) {
+		p.outro("Automatic upload settings saved.");
+		if (hookFailures > 0) {
+			return new Error(`${hookFailures} auto-upload hook change(s) failed.`);
+		}
+		return;
+	}
 
 	const uploadConfig: UploadConfig = {
 		endpoint: flags.endpoint,
@@ -136,20 +317,34 @@ async function runInteractiveUpload(
 
 	// Flatten all sessions with their project context for concurrent upload
 	const work: Array<{
-		session: (typeof selected)[number]["sessions"][number];
+		session: SessionFile;
 		project: ScannedProject;
 		adapter: ReturnType<typeof getAdapter>;
 		gitInfo: Awaited<ReturnType<typeof getGitInfo>>;
 		organizationId: string | undefined;
+		repositoryLabel: string;
 	}> = [];
 
-	for (const project of selected) {
-		const adapter = getAdapter(project.source);
-		const gitInfo = await getGitInfo(project.projectPath);
-		const organizationId =
-			flags.org ?? (await getProjectOrgId(project.projectPath));
-		for (const session of project.sessions) {
-			work.push({ session, project, adapter, gitInfo, organizationId });
+	for (const repository of selectedRepositories) {
+		for (const uploadProject of repository.projects) {
+			const project = uploadProject.project;
+			const adapter = getAdapter(project.source);
+			const gitInfo =
+				uploadProject.gitInfo ?? (await getGitInfo(project.projectPath));
+			const organizationId = uploadProject.organizationId;
+			for (const session of getSessionsToUpload(
+				uploadProject,
+				flags.forceReplace,
+			)) {
+				work.push({
+					adapter,
+					gitInfo,
+					organizationId,
+					project,
+					repositoryLabel: repository.label,
+					session,
+				});
+			}
 		}
 	}
 
@@ -161,7 +356,7 @@ async function runInteractiveUpload(
 
 	const items: InteractiveItem[] = work.map((w) => ({
 		sessionId: w.session.sessionId,
-		label: `${w.project.displayPath}/${w.session.sessionId}`,
+		label: `${w.repositoryLabel}/${w.session.sessionId}`,
 		transcriptPath: w.session.transcriptPath,
 		projectPath: w.session.projectPath,
 		source: w.project.source,
@@ -182,12 +377,12 @@ async function runInteractiveUpload(
 				organizationId: item.organizationId,
 				uploadMode: "manual",
 			});
-			if (flags.forceReplace) request.force_replace = true;
+			if (flags.forceReplace) request.metadata.force_replace = true;
 
 			if (!flags.tag && flags.classify) {
-				const classified = await classifySession(request.content);
+				const classified = await classifySessionFile(request.transcriptPath);
 				if (classified) {
-					(request as { tag?: string }).tag = classified;
+					request.metadata.tag = classified;
 				}
 			}
 
@@ -202,6 +397,197 @@ async function runInteractiveUpload(
 	if (summary.failed > 0) {
 		return new Error(`${summary.failed} upload(s) failed.`);
 	}
+	if (hookFailures > 0) {
+		return new Error(`${hookFailures} auto-upload hook change(s) failed.`);
+	}
+}
+
+async function prepareUploadTarget(
+	project: ScannedProject,
+	overrideOrganizationId: string | undefined,
+): Promise<PreparedUploadTarget> {
+	const pathIdentity = resolveRepoIdentity({
+		gitRemote: null,
+		packageName: null,
+		projectPath: project.projectPath,
+	});
+	const gitInfoPromise =
+		pathIdentity.worktree === null
+			? getGitInfo(project.projectPath)
+			: Promise.resolve(undefined);
+	const organizationIdPromise =
+		overrideOrganizationId === undefined
+			? getProjectOrgId(project.projectPath)
+			: Promise.resolve(overrideOrganizationId);
+	const [gitInfo, organizationId] = await Promise.all([
+		gitInfoPromise,
+		organizationIdPromise,
+	]);
+	const repositoryIdentity = gitInfo
+		? resolveRepoIdentity({
+				gitRemote: gitInfo.gitRemote ?? null,
+				packageName: gitInfo.packageName ?? null,
+				projectPath: project.projectPath,
+			})
+		: pathIdentity;
+
+	return {
+		metadata: {
+			gitInfo,
+			hookInstalled: getAdapter(project.source).isHookInstalled(),
+			repositoryIdentity,
+		},
+		target: { organizationId, project },
+	};
+}
+
+function getUploadProjectMetadata(
+	metadataByProject: ReadonlyMap<ScannedProject, UploadProjectMetadata>,
+	project: ScannedProject,
+): UploadProjectMetadata {
+	const metadata = metadataByProject.get(project);
+	if (!metadata) throw new Error("Upload project metadata is missing");
+	return metadata;
+}
+
+function isRepositoryAutoUploadSelected(
+	repository: InteractiveUploadRepository,
+	config: AutoUploadConfig | null,
+): boolean {
+	if (config) return config.repositories[repository.key] !== undefined;
+	return repository.projects.some((project) => project.hookInstalled);
+}
+
+function getRepositoryAutoUploadHint(
+	repository: InteractiveUploadRepository,
+	autoUploadSelected: boolean,
+	config: AutoUploadConfig | null,
+): string {
+	if (!autoUploadSelected) return "auto-upload off";
+	const installedBySource = new Map<Source, boolean>();
+	for (const project of repository.projects) {
+		const source = project.project.source;
+		const sourceSelected =
+			config === null ||
+			config.repositories[repository.key]?.sources.includes(source) === true;
+		installedBySource.set(source, sourceSelected && project.hookInstalled);
+	}
+	const states = Array.from(installedBySource.values());
+	if (states.every(Boolean)) return "auto-upload on";
+	if (states.every((installed) => !installed) && states.length === 1) {
+		return "auto-upload selected · hook missing";
+	}
+	return Array.from(
+		installedBySource,
+		([source, installed]) =>
+			`${getAdapterName(source)} ${installed ? "on" : "off"}`,
+	).join(" · ");
+}
+
+function getRepositoryUploadHint(
+	repository: InteractiveUploadRepository,
+): string {
+	const newSessions = repository.projects.reduce(
+		(sum, project) => sum + project.newSessions.length,
+		0,
+	);
+	const uploadedSessions = getRepositoryUploadedSessionCount(repository);
+	const duplicateSessions = getRepositoryDuplicateSessionCount(repository);
+	const statusKnown = repository.projects.every(
+		(project) => project.statusKnown,
+	);
+	if (!statusKnown) return sessionCountHint(newSessions);
+	const details = [`${newSessions} new`, `${uploadedSessions} uploaded`];
+	if (duplicateSessions > 0) {
+		details.push(`${duplicateSessions} local duplicate`);
+	}
+	return details.join(" · ");
+}
+
+function getRepositorySessionsToUpload(
+	repository: InteractiveUploadRepository,
+	forceReplace: boolean,
+): readonly SessionFile[] {
+	return repository.projects.flatMap((project) =>
+		getSessionsToUpload(project, forceReplace),
+	);
+}
+
+function getRepositoryUploadedSessionCount(
+	repository: InteractiveUploadRepository,
+): number {
+	return repository.projects.reduce(
+		(sum, project) => sum + project.uploadedSessions.length,
+		0,
+	);
+}
+
+function getRepositoryDuplicateSessionCount(
+	repository: InteractiveUploadRepository,
+): number {
+	return repository.projects.reduce(
+		(sum, project) => sum + project.duplicateSessions.length,
+		0,
+	);
+}
+
+function toAutoUploadRepositorySelection(
+	repository: InteractiveUploadRepository,
+): {
+	readonly key: string;
+	readonly label: string;
+	readonly sources: readonly Source[];
+} {
+	return {
+		key: repository.key,
+		label: repository.label,
+		sources: Array.from(
+			new Set(repository.projects.map((project) => project.project.source)),
+		),
+	};
+}
+
+function logAutoUploadSelectionPreview(
+	repositories: readonly InteractiveUploadRepository[],
+	selectedRepoKeys: ReadonlySet<string>,
+	config: AutoUploadConfig | null,
+): void {
+	for (const repository of repositories) {
+		const currentlySelected = isRepositoryAutoUploadSelected(
+			repository,
+			config,
+		);
+		const willBeSelected = selectedRepoKeys.has(repository.key);
+		if (currentlySelected === willBeSelected) continue;
+		p.log.info(
+			`Would ${willBeSelected ? "enable" : "disable"} automatic upload for ${repository.label}`,
+		);
+	}
+}
+
+function reconcileAutoUploadHooks(config: AutoUploadConfig): number {
+	const requiredSources = getRequiredAutoUploadSources(config);
+	let failures = 0;
+	for (const adapter of getAllAdapters()) {
+		const required = requiredSources.has(adapter.source);
+		const installed = adapter.isHookInstalled();
+		if (required === installed) continue;
+		try {
+			if (required) {
+				adapter.installHook();
+				p.log.success(`${adapter.name}: automatic upload hook enabled`);
+			} else {
+				adapter.removeHook();
+				p.log.success(`${adapter.name}: automatic upload hook removed`);
+			}
+		} catch (error) {
+			failures++;
+			p.log.error(
+				`${adapter.name}: could not ${required ? "enable" : "remove"} automatic upload hook (${error instanceof Error ? error.message : String(error)})`,
+			);
+		}
+	}
+	return failures;
 }
 
 function getAdapterName(source: Source): string {
@@ -210,6 +596,32 @@ function getAdapterName(source: Source): string {
 
 function sessionCountHint(count: number): string {
 	return `${count} session${count !== 1 ? "s" : ""}`;
+}
+
+function repositoryCountHint(count: number): string {
+	return count === 1 ? "repository" : "repositories";
+}
+
+function getSessionsToUpload(
+	project: InteractiveUploadProject,
+	forceReplace: boolean,
+): readonly SessionFile[] {
+	return forceReplace
+		? [...project.newSessions, ...project.uploadedSessions]
+		: project.newSessions;
+}
+
+function logSkippedSessions(uploaded: number, duplicates: number): void {
+	if (uploaded > 0) {
+		p.log.info(
+			`Skipping ${sessionCountHint(uploaded)} already uploaded to Opaline.`,
+		);
+	}
+	if (duplicates > 0) {
+		p.log.info(
+			`Skipping ${sessionCountHint(duplicates)} duplicated in local discovery.`,
+		);
+	}
 }
 
 async function runSingleUpload(
@@ -250,7 +662,7 @@ async function runSingleUpload(
 		projectPath: sessionInfo.projectPath,
 	};
 
-	let request: IngestSessionInput;
+	let request: FileBackedUploadRequest;
 	try {
 		request = await claudeCodeAdapter.buildUploadRequest(sessionFile, {
 			tag: flags.tag,
@@ -267,21 +679,25 @@ async function runSingleUpload(
 		throw error;
 	}
 
-	write(`Transcript: ${request.content.length} bytes`);
-	if (request.subagents && request.subagents.length > 0) {
+	const transcriptBytes = (await stat(request.transcriptPath)).size;
+	write(`Transcript: ${transcriptBytes} bytes`);
+	if (request.subagents.length > 0) {
 		write(`Subagents: ${request.subagents.length} file(s)`);
 	}
 
-	if (flags.forceReplace) request.force_replace = true;
+	if (flags.forceReplace) request.metadata.force_replace = true;
 
 	if (flags.dryRun) {
-		const preview = {
-			...request,
-			content: `[${request.content.length} bytes]`,
-			subagents: request.subagents?.map((s) => ({
-				...s,
-				content: `[${s.content.length} bytes]`,
+		const subagents = await Promise.all(
+			request.subagents.map(async (subagent) => ({
+				agentId: subagent.agentId,
+				content: `[${(await stat(subagent.path)).size} bytes]`,
 			})),
+		);
+		const preview = {
+			...request.metadata,
+			content: `[${transcriptBytes} bytes]`,
+			subagents: subagents.length > 0 ? subagents : undefined,
 		};
 		write("Dry run - would upload:");
 		write(JSON.stringify(preview, null, 2));
@@ -294,9 +710,9 @@ async function runSingleUpload(
 
 	if (!flags.tag && flags.classify) {
 		write("Classifying session...");
-		const classified = await classifySession(request.content);
+		const classified = await classifySessionFile(request.transcriptPath);
 		if (classified) {
-			(request as { tag?: string }).tag = classified;
+			request.metadata.tag = classified;
 			write(`Classified as: ${classified}`);
 		}
 	}
@@ -311,7 +727,7 @@ async function runSingleUpload(
 
 	if (result.success) {
 		write("Upload successful!");
-		await removeFailedUpload(request.sessionId);
+		await removeFailedUpload(request.metadata.sessionId);
 		const redactionSummary = formatRedactionSummary(
 			result.redacted,
 			result.redactedBytes,
@@ -427,7 +843,7 @@ async function runRetryUpload(
 				organizationId,
 				uploadMode: "retry",
 			});
-			if (flags.forceReplace) request.force_replace = true;
+			if (flags.forceReplace) request.metadata.force_replace = true;
 
 			return uploadSession(request, {
 				endpoint: flags.endpoint,
@@ -563,6 +979,6 @@ export const uploadCommand = buildCommand({
 	},
 	docs: {
 		brief:
-			"Upload session transcripts (Claude Code / Codex). No args = interactive project picker.",
+			"Sync sessions and manage automatic upload by repository. Pass a session for a one-off upload.",
 	},
 });

--- a/apps/cli/src/contracts/index.ts
+++ b/apps/cli/src/contracts/index.ts
@@ -26,7 +26,11 @@ export {
 	type ProductAnalyticsPlatformOs,
 	parseProductAnalyticsEvent,
 } from "./product-analytics.js";
-export { contract } from "./rpc.js";
+export {
+	type RepoIdentity,
+	resolveRepoIdentity,
+} from "./repo-identity.js";
+export { CLI_SESSION_UPLOAD_STATUS_MAX_IDS, contract } from "./rpc.js";
 export {
 	parseSafeApiBase,
 	parseSafeApiEndpoint,

--- a/apps/cli/src/contracts/repo-identity.ts
+++ b/apps/cli/src/contracts/repo-identity.ts
@@ -1,0 +1,88 @@
+export type RepoIdentity = {
+	/** Stable grouping key. Namespaced to avoid cross-tier collisions. */
+	repoKey: string;
+	/** What the user sees in repository columns and filters. */
+	repoLabel: string;
+	/** Worktree name when the path matched a worktree layout, else null. */
+	worktree: string | null;
+};
+
+type RepoPathMatch = {
+	repoToken: string;
+	worktree: string;
+};
+
+type RepoPathRule = {
+	name: string;
+	match: (normalizedPath: string) => RepoPathMatch | null;
+};
+
+const REPO_PATH_RULES: readonly RepoPathRule[] = [
+	{
+		name: "conductor",
+		match(normalizedPath) {
+			const match = normalizedPath.match(
+				/(?:^|\/)conductor\/workspaces\/([^/]+)\/([^/]+)(?:\/|$)/,
+			);
+			const repoToken = match?.[1];
+			const worktree = match?.[2];
+
+			return repoToken && worktree ? { repoToken, worktree } : null;
+		},
+	},
+	{
+		name: "dot-worktrees",
+		match(normalizedPath) {
+			const match = normalizedPath.match(
+				/(?:^|\/)([^/]+)\/\.worktrees\/([^/]+)(?:\/|$)/,
+			);
+			const repoToken = match?.[1];
+			const worktree = match?.[2];
+
+			return repoToken && worktree ? { repoToken, worktree } : null;
+		},
+	},
+];
+
+export function resolveRepoIdentity(input: {
+	projectPath: string;
+	gitRemote: string | null;
+	packageName: string | null;
+}): RepoIdentity {
+	const normalizedPath = input.projectPath.replace(/\\/g, "/");
+
+	for (const rule of REPO_PATH_RULES) {
+		const pathMatch = rule.match(normalizedPath);
+		if (pathMatch) {
+			return {
+				repoKey: `path:${pathMatch.repoToken}`,
+				repoLabel: pathMatch.repoToken,
+				worktree: pathMatch.worktree,
+			};
+		}
+	}
+
+	if (input.gitRemote) {
+		const remoteSegments = input.gitRemote.split("/").filter(Boolean);
+		return {
+			repoKey: `remote:${input.gitRemote}`,
+			repoLabel: remoteSegments.slice(-2).join("/"),
+			worktree: null,
+		};
+	}
+
+	if (input.packageName) {
+		return {
+			repoKey: `pkg:${input.packageName}`,
+			repoLabel: input.packageName,
+			worktree: null,
+		};
+	}
+
+	const pathSegments = normalizedPath.split("/").filter(Boolean);
+	return {
+		repoKey: `path-raw:${input.projectPath}`,
+		repoLabel: pathSegments.slice(-2).join("/") || "Untitled project",
+		worktree: null,
+	};
+}

--- a/apps/cli/src/contracts/rpc.ts
+++ b/apps/cli/src/contracts/rpc.ts
@@ -27,6 +27,24 @@ const CliUserSchema = z.object({
 	email: z.string(),
 	name: z.string(),
 });
+// Keep UUID-sized batches below common reverse-proxy URI limits.
+export const CLI_SESSION_UPLOAD_STATUS_MAX_IDS = 64;
+
+const CliSessionUploadStatusInputSchema = z.object({
+	organizationId: z.string().max(200).optional(),
+	sessionIds: z
+		.array(z.string().min(1).max(200))
+		.min(1)
+		.max(CLI_SESSION_UPLOAD_STATUS_MAX_IDS)
+		.refine((sessionIds) => new Set(sessionIds).size === sessionIds.length, {
+			message: "Session IDs must be unique",
+		}),
+});
+
+const CliSessionUploadStatusOutputSchema = z.object({
+	organizationId: z.string(),
+	uploadedSessionIds: z.array(z.string()),
+});
 const OrganizationSchema = z.object({
 	id: z.string(),
 	name: z.string(),
@@ -39,6 +57,9 @@ export const contract = {
 	cli: {
 		authStatus: oc.output(CliUserSchema),
 		revokeToken: oc.output(z.object({ success: z.literal(true) })),
+		sessionUploadStatus: oc
+			.input(CliSessionUploadStatusInputSchema)
+			.output(CliSessionUploadStatusOutputSchema),
 	},
 	listMyOrganizations: oc.output(z.array(OrganizationSchema)),
 	ingestSession: oc

--- a/apps/cli/src/internal/agent-adapters/adapters/claude-code/index.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/claude-code/index.ts
@@ -1,16 +1,19 @@
+import { createReadStream } from "node:fs";
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
-import type { IngestSessionInput } from "../../../../contracts/index.js";
+import { createInterface } from "node:readline";
 import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
 	AgentAdapter,
+	FileBackedUploadRequest,
+	FileBackedUploadSubagent,
 	ScannedProject,
 	SessionFile,
 	SessionTimestamps,
 	UploadContext,
 } from "../../types.js";
-import { readFileWithRetry, toDisplayPath } from "../../utils.js";
+import { toDisplayPath } from "../../utils.js";
 import {
 	addHook,
 	getClaudeSettingsPath,
@@ -99,6 +102,72 @@ export function extractAgentIds(sessionContent: string): string[] {
 interface SubagentFile {
 	agentId: string;
 	content: string;
+}
+
+async function resolveSubagentFilePaths(
+	sessionDir: string,
+	agentIds: string[],
+	sessionId?: string,
+): Promise<FileBackedUploadSubagent[]> {
+	const subagents: FileBackedUploadSubagent[] = [];
+	const subagentDirs = await resolveSubagentDirectories(sessionDir, sessionId);
+
+	for (const agentId of agentIds) {
+		if (!isSafeBasename(agentId)) continue;
+
+		for (const subagentDir of subagentDirs) {
+			let agentPath: string;
+			try {
+				agentPath = await realpath(join(subagentDir, `agent-${agentId}.jsonl`));
+			} catch {
+				continue;
+			}
+			if (!isContainedPath(subagentDir, agentPath)) continue;
+			subagents.push({ agentId, path: agentPath });
+			break;
+		}
+	}
+
+	return subagents;
+}
+
+async function scanUploadTranscript(path: string): Promise<{
+	agentIds: string[];
+	hasTimestamp: boolean;
+}> {
+	const agentIds = new Set<string>();
+	let hasTimestamp = false;
+	const input = createReadStream(path, {
+		encoding: "utf8",
+		highWaterMark: 64 * 1024,
+	});
+	const lines = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
+	try {
+		for await (const line of lines) {
+			if (!line) continue;
+			let entry: unknown;
+			try {
+				entry = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (!isRecord(entry)) continue;
+			if (
+				(entry.type === "user" || entry.type === "assistant") &&
+				typeof entry.timestamp === "string" &&
+				Number.isFinite(Date.parse(entry.timestamp))
+			) {
+				hasTimestamp = true;
+			}
+			if (!isRecord(entry.toolUseResult)) continue;
+			const agentId = entry.toolUseResult.agentId;
+			if (isSafeBasename(agentId)) agentIds.add(agentId);
+		}
+	} finally {
+		lines.close();
+		input.destroy();
+	}
+	return { agentIds: Array.from(agentIds), hasTimestamp };
 }
 
 export async function readSubagentFiles(
@@ -218,33 +287,39 @@ class ClaudeCodeAdapter implements AgentAdapter {
 	async buildUploadRequest(
 		session: SessionFile,
 		context: UploadContext,
-	): Promise<IngestSessionInput> {
-		const content = await readFileWithRetry(session.transcriptPath);
-		if (!this.extractTimestamps(content)) {
+	): Promise<FileBackedUploadRequest> {
+		const scan = await scanUploadTranscript(session.transcriptPath);
+		if (!scan.hasTimestamp) {
 			throw new MissingTranscriptTimestampError(this.source);
 		}
 
-		const agentIds = extractAgentIds(content);
 		const sessionDir = dirname(session.transcriptPath);
 		const subagents =
-			agentIds.length > 0
-				? await readSubagentFiles(sessionDir, agentIds, session.sessionId)
+			scan.agentIds.length > 0
+				? await resolveSubagentFilePaths(
+						sessionDir,
+						scan.agentIds,
+						session.sessionId,
+					)
 				: [];
 
 		return {
-			source: this.source,
-			sessionId: session.sessionId,
-			projectPath: session.projectPath,
-			gitRemote: context.gitInfo.gitRemote,
-			packageName: context.gitInfo.packageName,
-			packageType: context.gitInfo.packageType,
-			gitBranch: context.gitInfo.branch,
-			gitSha: context.gitInfo.sha,
-			tag: context.tag,
-			content,
-			subagents: subagents.length > 0 ? subagents : undefined,
-			organizationId: context.organizationId,
-			upload_mode: context.uploadMode,
+			kind: "file",
+			metadata: {
+				source: this.source,
+				sessionId: session.sessionId,
+				projectPath: session.projectPath,
+				gitRemote: context.gitInfo.gitRemote,
+				packageName: context.gitInfo.packageName,
+				packageType: context.gitInfo.packageType,
+				gitBranch: context.gitInfo.branch,
+				gitSha: context.gitInfo.sha,
+				tag: context.tag,
+				organizationId: context.organizationId,
+				upload_mode: context.uploadMode,
+			},
+			subagents,
+			transcriptPath: session.transcriptPath,
 		};
 	}
 

--- a/apps/cli/src/internal/agent-adapters/adapters/claude-code/index.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/claude-code/index.ts
@@ -1,8 +1,7 @@
-import { createReadStream } from "node:fs";
 import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
-import { createInterface } from "node:readline";
+import { scanBoundedJsonlFile } from "../../bounded-jsonl-scan.js";
 import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
 	AgentAdapter,
@@ -135,39 +134,35 @@ async function scanUploadTranscript(path: string): Promise<{
 	agentIds: string[];
 	hasTimestamp: boolean;
 }> {
-	const agentIds = new Set<string>();
-	let hasTimestamp = false;
-	const input = createReadStream(path, {
-		encoding: "utf8",
-		highWaterMark: 64 * 1024,
-	});
-	const lines = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
-	try {
-		for await (const line of lines) {
-			if (!line) continue;
+	const state = await scanBoundedJsonlFile(
+		path,
+		() => ({ agentIds: new Set<string>(), hasTimestamp: false }),
+		(line, scanState) => {
+			if (!line) return true;
 			let entry: unknown;
 			try {
 				entry = JSON.parse(line);
 			} catch {
-				continue;
+				return true;
 			}
-			if (!isRecord(entry)) continue;
+			if (!isRecord(entry)) return true;
 			if (
 				(entry.type === "user" || entry.type === "assistant") &&
 				typeof entry.timestamp === "string" &&
 				Number.isFinite(Date.parse(entry.timestamp))
 			) {
-				hasTimestamp = true;
+				scanState.hasTimestamp = true;
 			}
-			if (!isRecord(entry.toolUseResult)) continue;
+			if (!isRecord(entry.toolUseResult)) return true;
 			const agentId = entry.toolUseResult.agentId;
-			if (isSafeBasename(agentId)) agentIds.add(agentId);
-		}
-	} finally {
-		lines.close();
-		input.destroy();
-	}
-	return { agentIds: Array.from(agentIds), hasTimestamp };
+			if (isSafeBasename(agentId)) scanState.agentIds.add(agentId);
+			return true;
+		},
+	);
+	return {
+		agentIds: Array.from(state.agentIds),
+		hasTimestamp: state.hasTimestamp,
+	};
 }
 
 export async function readSubagentFiles(

--- a/apps/cli/src/internal/agent-adapters/adapters/codex/index.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/codex/index.ts
@@ -1,10 +1,11 @@
-import { readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { IngestSessionInput } from "../../../../contracts/index.js";
+import { createInterface } from "node:readline";
 import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
 	AgentAdapter,
+	FileBackedUploadRequest,
 	ScannedProject,
 	SessionFile,
 	SessionTimestamps,
@@ -23,6 +24,36 @@ import {
 } from "./config.js";
 
 const SESSIONS_BASE_DIR = join(homedir(), ".codex", "sessions");
+
+async function transcriptHasTimestamp(path: string): Promise<boolean> {
+	const input = createReadStream(path, {
+		encoding: "utf8",
+		highWaterMark: 64 * 1024,
+	});
+	const lines = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
+	try {
+		for await (const line of lines) {
+			if (!line) continue;
+			let entry: unknown;
+			try {
+				entry = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (
+				isRecord(entry) &&
+				typeof entry.timestamp === "string" &&
+				Number.isFinite(Date.parse(entry.timestamp))
+			) {
+				return true;
+			}
+		}
+		return false;
+	} finally {
+		lines.close();
+		input.destroy();
+	}
+}
 
 // ── Exported utilities ──
 
@@ -164,25 +195,28 @@ class CodexAdapter implements AgentAdapter {
 	async buildUploadRequest(
 		session: SessionFile,
 		context: UploadContext,
-	): Promise<IngestSessionInput> {
-		const content = await readFile(session.transcriptPath, "utf-8");
-		if (!this.extractTimestamps(content)) {
+	): Promise<FileBackedUploadRequest> {
+		if (!(await transcriptHasTimestamp(session.transcriptPath))) {
 			throw new MissingTranscriptTimestampError(this.source);
 		}
 
 		return {
-			source: this.source,
-			sessionId: session.sessionId,
-			projectPath: session.projectPath,
-			gitRemote: context.gitInfo.gitRemote,
-			packageName: context.gitInfo.packageName,
-			packageType: context.gitInfo.packageType,
-			gitBranch: session.gitBranch ?? context.gitInfo.branch,
-			gitSha: session.gitSha ?? context.gitInfo.sha,
-			tag: context.tag,
-			content,
-			organizationId: context.organizationId,
-			upload_mode: context.uploadMode,
+			kind: "file",
+			metadata: {
+				source: this.source,
+				sessionId: session.sessionId,
+				projectPath: session.projectPath,
+				gitRemote: context.gitInfo.gitRemote,
+				packageName: context.gitInfo.packageName,
+				packageType: context.gitInfo.packageType,
+				gitBranch: session.gitBranch ?? context.gitInfo.branch,
+				gitSha: session.gitSha ?? context.gitInfo.sha,
+				tag: context.tag,
+				organizationId: context.organizationId,
+				upload_mode: context.uploadMode,
+			},
+			subagents: [],
+			transcriptPath: session.transcriptPath,
 		};
 	}
 

--- a/apps/cli/src/internal/agent-adapters/adapters/codex/index.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/codex/index.ts
@@ -1,7 +1,6 @@
-import { createReadStream } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { createInterface } from "node:readline";
+import { scanBoundedJsonlFile } from "../../bounded-jsonl-scan.js";
 import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
 	AgentAdapter,
@@ -26,33 +25,25 @@ import {
 const SESSIONS_BASE_DIR = join(homedir(), ".codex", "sessions");
 
 async function transcriptHasTimestamp(path: string): Promise<boolean> {
-	const input = createReadStream(path, {
-		encoding: "utf8",
-		highWaterMark: 64 * 1024,
-	});
-	const lines = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
-	try {
-		for await (const line of lines) {
-			if (!line) continue;
+	const state = await scanBoundedJsonlFile(
+		path,
+		() => ({ hasTimestamp: false }),
+		(line, scanState) => {
+			if (!line) return true;
 			let entry: unknown;
 			try {
 				entry = JSON.parse(line);
 			} catch {
-				continue;
-			}
-			if (
-				isRecord(entry) &&
-				typeof entry.timestamp === "string" &&
-				Number.isFinite(Date.parse(entry.timestamp))
-			) {
 				return true;
 			}
-		}
-		return false;
-	} finally {
-		lines.close();
-		input.destroy();
-	}
+			scanState.hasTimestamp =
+				isRecord(entry) &&
+				typeof entry.timestamp === "string" &&
+				Number.isFinite(Date.parse(entry.timestamp));
+			return !scanState.hasTimestamp;
+		},
+	);
+	return state.hasTimestamp;
 }
 
 // ── Exported utilities ──

--- a/apps/cli/src/internal/agent-adapters/bounded-jsonl-scan.ts
+++ b/apps/cli/src/internal/agent-adapters/bounded-jsonl-scan.ts
@@ -1,0 +1,98 @@
+import { createReadStream } from "node:fs";
+import { MAX_STREAM_RECORD_BYTES } from "../../lib/filtered-upload-staging.js";
+
+const MAX_SCAN_ATTEMPTS = 5;
+const SCAN_RETRY_DELAY_MS = 500;
+const NEWLINE_BYTE = 0x0a;
+
+export async function scanBoundedJsonlFile<State>(
+	path: string,
+	createState: () => State,
+	onRecord: (record: string, state: State) => boolean,
+): Promise<State> {
+	for (let attempt = 1; attempt <= MAX_SCAN_ATTEMPTS; attempt++) {
+		const state = createState();
+		try {
+			await scanOnce(path, (record) => onRecord(record, state));
+			return state;
+		} catch (error) {
+			if (error instanceof RecordVisitorError) throw error.cause;
+			if (attempt === MAX_SCAN_ATTEMPTS) throw error;
+			await new Promise((resolve) => setTimeout(resolve, SCAN_RETRY_DELAY_MS));
+		}
+	}
+	throw new Error(`Failed to scan JSONL file: ${path}`);
+}
+
+async function scanOnce(
+	path: string,
+	onRecord: (record: string) => boolean,
+): Promise<void> {
+	const input = createReadStream(path, { highWaterMark: 64 * 1024 });
+	let chunks: Buffer[] = [];
+	let recordBytes = 0;
+	let oversized = false;
+
+	try {
+		for await (const rawChunk of input) {
+			const chunk = Buffer.from(rawChunk);
+			let offset = 0;
+			while (offset < chunk.byteLength) {
+				const newlineIndex = chunk.indexOf(NEWLINE_BYTE, offset);
+				const end = newlineIndex < 0 ? chunk.byteLength : newlineIndex;
+				const segment = chunk.subarray(offset, end);
+				recordBytes += segment.byteLength;
+				if (!oversized) {
+					if (recordBytes > MAX_STREAM_RECORD_BYTES) {
+						oversized = true;
+						chunks = [];
+					} else if (segment.byteLength > 0) {
+						chunks.push(segment);
+					}
+				}
+
+				if (newlineIndex < 0) break;
+				recordBytes += 1;
+				if (
+					!oversized &&
+					recordBytes <= MAX_STREAM_RECORD_BYTES &&
+					!visitRecord(chunks, recordBytes - 1, onRecord)
+				) {
+					return;
+				}
+				chunks = [];
+				recordBytes = 0;
+				oversized = false;
+				offset = newlineIndex + 1;
+			}
+		}
+
+		if (
+			!oversized &&
+			recordBytes > 0 &&
+			recordBytes <= MAX_STREAM_RECORD_BYTES
+		) {
+			visitRecord(chunks, recordBytes, onRecord);
+		}
+	} finally {
+		input.destroy();
+	}
+}
+
+function visitRecord(
+	chunks: Buffer[],
+	byteLength: number,
+	onRecord: (record: string) => boolean,
+): boolean {
+	try {
+		return onRecord(Buffer.concat(chunks, byteLength).toString("utf8"));
+	} catch (cause) {
+		throw new RecordVisitorError(cause);
+	}
+}
+
+class RecordVisitorError extends Error {
+	constructor(readonly cause: unknown) {
+		super("JSONL record visitor failed");
+	}
+}

--- a/apps/cli/src/internal/agent-adapters/index.ts
+++ b/apps/cli/src/internal/agent-adapters/index.ts
@@ -22,6 +22,8 @@ export {
 } from "./registry.js";
 export type {
 	AgentAdapter,
+	FileBackedUploadRequest,
+	FileBackedUploadSubagent,
 	GitInfo,
 	ScannedProject,
 	SessionFile,

--- a/apps/cli/src/internal/agent-adapters/types.ts
+++ b/apps/cli/src/internal/agent-adapters/types.ts
@@ -31,6 +31,18 @@ export interface UploadContext {
 	uploadMode: IngestSessionInput["upload_mode"];
 }
 
+export interface FileBackedUploadSubagent {
+	agentId: string;
+	path: string;
+}
+
+export interface FileBackedUploadRequest {
+	kind: "file";
+	metadata: Omit<IngestSessionInput, "content" | "subagents">;
+	subagents: FileBackedUploadSubagent[];
+	transcriptPath: string;
+}
+
 export interface SessionTimestamps {
 	sessionDate: string;
 	lastInteractionDate: string;
@@ -55,7 +67,7 @@ export interface AgentAdapter {
 	buildUploadRequest(
 		session: SessionFile,
 		context: UploadContext,
-	): Promise<IngestSessionInput>;
+	): Promise<FileBackedUploadRequest>;
 
 	extractTimestamps(content: string): SessionTimestamps | null;
 }

--- a/apps/cli/src/lib/api-client.ts
+++ b/apps/cli/src/lib/api-client.ts
@@ -10,8 +10,24 @@ export interface ClientConfig {
 	authType?: "bearer" | "api-key";
 }
 
+export interface RpcClientConfig {
+	rpcUrl: string;
+	token: string;
+	authType?: "bearer" | "api-key";
+}
+
 export function createApiClient(
 	config: ClientConfig,
+): ContractRouterClient<typeof contract> {
+	return createRpcClient({
+		rpcUrl: `${config.apiBaseUrl.replace(/\/+$/u, "")}/rpc`,
+		token: config.token,
+		authType: config.authType,
+	});
+}
+
+export function createRpcClient(
+	config: RpcClientConfig,
 ): ContractRouterClient<typeof contract> {
 	const authType = config.authType ?? "bearer";
 	const authHeaders =
@@ -19,12 +35,12 @@ export function createApiClient(
 			? { "x-api-key": config.token }
 			: { Authorization: `Bearer ${config.token}` };
 	debugLog("creating API client", {
-		apiBaseUrl: config.apiBaseUrl,
+		apiBaseUrl: config.rpcUrl,
 		authType,
 	});
 
 	const link = new RPCLink({
-		url: `${config.apiBaseUrl}/rpc`,
+		url: config.rpcUrl,
 		headers: authHeaders,
 	});
 	return createORPCClient(link);

--- a/apps/cli/src/lib/auto-upload-config.ts
+++ b/apps/cli/src/lib/auto-upload-config.ts
@@ -1,0 +1,177 @@
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { type Source, SourceSchema } from "../contracts/index.js";
+import { getConfigDir } from "./local-state.js";
+
+const AUTO_UPLOAD_CONFIG_VERSION = 1;
+
+export interface AutoUploadRepositorySelection {
+	readonly key: string;
+	readonly label: string;
+	readonly sources: readonly Source[];
+}
+
+interface AutoUploadRepositoryEntry {
+	readonly label: string;
+	readonly sources: readonly Source[];
+}
+
+export interface AutoUploadConfig {
+	readonly repositories: Readonly<Record<string, AutoUploadRepositoryEntry>>;
+	readonly version: typeof AUTO_UPLOAD_CONFIG_VERSION;
+}
+
+export function loadAutoUploadConfig(): AutoUploadConfig | null {
+	const path = getAutoUploadConfigPath();
+	if (!existsSync(path)) return null;
+	repairConfigPermissions(path);
+	return parseAutoUploadConfig(JSON.parse(readFileSync(path, "utf8")));
+}
+
+export function isRepositoryAutoUploadAllowed(
+	repoKey: string,
+	source: Source,
+): boolean {
+	const config = loadAutoUploadConfig();
+	if (config === null) return true;
+	return config.repositories[repoKey]?.sources.includes(source) ?? false;
+}
+
+export function saveVisibleAutoUploadSelections(
+	visibleRepositories: readonly AutoUploadRepositorySelection[],
+	selectedRepoKeys: ReadonlySet<string>,
+): AutoUploadConfig {
+	const existing = loadAutoUploadConfig();
+	const visibleRepoKeys = new Set(
+		visibleRepositories.map((repository) => repository.key),
+	);
+	const repositories: Record<string, AutoUploadRepositoryEntry> = {};
+
+	if (existing) {
+		for (const [key, repository] of Object.entries(existing.repositories)) {
+			if (!visibleRepoKeys.has(key)) repositories[key] = repository;
+		}
+	}
+
+	for (const repository of visibleRepositories) {
+		if (!selectedRepoKeys.has(repository.key)) continue;
+		repositories[repository.key] = {
+			label: repository.label,
+			sources: uniqueSources(repository.sources),
+		};
+	}
+
+	const config: AutoUploadConfig = {
+		repositories,
+		version: AUTO_UPLOAD_CONFIG_VERSION,
+	};
+	saveAutoUploadConfig(config);
+	return config;
+}
+
+export function enableAutoUploadRepository(
+	repository: AutoUploadRepositorySelection,
+): AutoUploadConfig {
+	const existing = loadAutoUploadConfig();
+	const repositories: Record<string, AutoUploadRepositoryEntry> = {
+		...(existing?.repositories ?? {}),
+		[repository.key]: {
+			label: repository.label,
+			sources: uniqueSources(repository.sources),
+		},
+	};
+	const config: AutoUploadConfig = {
+		repositories,
+		version: AUTO_UPLOAD_CONFIG_VERSION,
+	};
+	saveAutoUploadConfig(config);
+	return config;
+}
+
+export function clearAutoUploadRepositories(): AutoUploadConfig {
+	const config: AutoUploadConfig = {
+		repositories: {},
+		version: AUTO_UPLOAD_CONFIG_VERSION,
+	};
+	saveAutoUploadConfig(config);
+	return config;
+}
+
+export function getRequiredAutoUploadSources(
+	config: AutoUploadConfig,
+): ReadonlySet<Source> {
+	const sources = new Set<Source>();
+	for (const repository of Object.values(config.repositories)) {
+		for (const source of repository.sources) sources.add(source);
+	}
+	return sources;
+}
+
+function getAutoUploadConfigPath(): string {
+	return join(getConfigDir(), "auto-upload.json");
+}
+
+function saveAutoUploadConfig(config: AutoUploadConfig): void {
+	const dir = getConfigDir();
+	mkdirSync(dir, { recursive: true, mode: 0o700 });
+	chmodSync(dir, 0o700);
+	const path = getAutoUploadConfigPath();
+	writeFileSync(path, JSON.stringify(config, null, 2), { mode: 0o600 });
+	chmodSync(path, 0o600);
+}
+
+function repairConfigPermissions(path: string): void {
+	const dir = getConfigDir();
+	chmodSync(dir, 0o700);
+	chmodSync(path, 0o600);
+}
+
+function parseAutoUploadConfig(value: unknown): AutoUploadConfig {
+	if (!isRecord(value) || value.version !== AUTO_UPLOAD_CONFIG_VERSION) {
+		throw new Error("Invalid auto-upload configuration version");
+	}
+	if (!isRecord(value.repositories)) {
+		throw new Error("Invalid auto-upload repository configuration");
+	}
+
+	const repositories: Record<string, AutoUploadRepositoryEntry> = {};
+	for (const [key, entry] of Object.entries(value.repositories)) {
+		if (!isRecord(entry) || typeof entry.label !== "string") {
+			throw new Error(`Invalid auto-upload configuration for ${key}`);
+		}
+		if (!Array.isArray(entry.sources)) {
+			throw new Error(`Invalid auto-upload sources for ${key}`);
+		}
+		const sources: Source[] = [];
+		for (const source of entry.sources) {
+			const parsed = SourceSchema.safeParse(source);
+			if (!parsed.success) {
+				throw new Error(`Invalid auto-upload source for ${key}`);
+			}
+			sources.push(parsed.data);
+		}
+		repositories[key] = {
+			label: entry.label,
+			sources: uniqueSources(sources),
+		};
+	}
+
+	return {
+		repositories,
+		version: AUTO_UPLOAD_CONFIG_VERSION,
+	};
+}
+
+function uniqueSources(sources: readonly Source[]): Source[] {
+	return Array.from(new Set(sources));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/cli/src/lib/classifier.ts
+++ b/apps/cli/src/lib/classifier.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { open } from "node:fs/promises";
 import { SESSION_TAGS, type SessionTag } from "./types.js";
 
 const SYSTEM_PROMPT = `You are a session classifier. Analyze the Claude Code / Codex session transcript and classify it into exactly ONE of these categories:
@@ -59,6 +60,19 @@ export async function classifySession(
 		return "other";
 	} catch {
 		return undefined;
+	}
+}
+
+export async function classifySessionFile(
+	path: string,
+): Promise<SessionTag | undefined> {
+	const file = await open(path, "r");
+	try {
+		const buffer = Buffer.allocUnsafe(50_000);
+		const { bytesRead } = await file.read(buffer, 0, buffer.byteLength, 0);
+		return classifySession(buffer.subarray(0, bytesRead).toString("utf8"));
+	} finally {
+		await file.close();
 	}
 }
 

--- a/apps/cli/src/lib/filtered-upload-staging.ts
+++ b/apps/cli/src/lib/filtered-upload-staging.ts
@@ -18,7 +18,7 @@ import {
 	R2_UPLOAD_STAGING_DIRECTORY_PREFIX,
 } from "./r2-staging-cleanup.js";
 
-const MAX_STREAM_RECORD_BYTES = 16 * 1024 * 1024;
+export const MAX_STREAM_RECORD_BYTES = 16 * 1024 * 1024;
 
 export type TranscriptSource =
 	| { readonly content: string; readonly kind: "text" }

--- a/apps/cli/src/lib/filtered-upload-staging.ts
+++ b/apps/cli/src/lib/filtered-upload-staging.ts
@@ -1,0 +1,282 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { open, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+import type { IngestSessionInput } from "../contracts/index.js";
+import type { FileBackedUploadRequest } from "../internal/agent-adapters/index.js";
+import {
+	FILTER_VERSION,
+	filterSessionTextFields,
+	mergeRedactionCounts,
+	type RedactionCounts,
+} from "../internal/secret-filter/index.js";
+import type { R2IngestMetadata } from "./r2-ingest-contract.js";
+import {
+	cleanupOwnedR2StagingDirectory,
+	createOwnedR2StagingDirectory,
+	R2_UPLOAD_STAGING_DIRECTORY_PREFIX,
+} from "./r2-staging-cleanup.js";
+
+const MAX_STREAM_RECORD_BYTES = 16 * 1024 * 1024;
+
+export type TranscriptSource =
+	| { readonly content: string; readonly kind: "text" }
+	| { readonly kind: "file"; readonly path: string };
+
+export interface FilteredUploadSubagentSource {
+	readonly agentId: string;
+	readonly source: TranscriptSource;
+}
+
+export interface FilteredUploadSources {
+	readonly main: TranscriptSource;
+	readonly metadata: R2IngestMetadata;
+	readonly subagents: readonly FilteredUploadSubagentSource[];
+}
+
+interface StagedUploadObjectBase {
+	readonly byteLength: number;
+	readonly path: string;
+	readonly sha256: string;
+}
+
+export type StagedUploadObject =
+	| (StagedUploadObjectBase & { readonly kind: "main" })
+	| (StagedUploadObjectBase & {
+			readonly agentId: string;
+			readonly kind: "subagent";
+	  });
+
+export interface StagedFilteredUpload {
+	readonly aggregateBytes: number;
+	readonly directory: string;
+	readonly inputBytes: number;
+	readonly metadata: R2IngestMetadata;
+	readonly objects: readonly StagedUploadObject[];
+	readonly redactedBytes: number;
+	readonly redactions: RedactionCounts;
+}
+
+interface FilteredFileResult {
+	readonly byteLength: number;
+	readonly inputBytes: number;
+	readonly redactedBytes: number;
+	readonly redactions: RedactionCounts;
+	readonly sha256: string;
+}
+
+export function createFilteredUploadSources(
+	request: IngestSessionInput | FileBackedUploadRequest,
+): FilteredUploadSources {
+	if (isFileBackedUploadRequest(request)) {
+		return {
+			main: { kind: "file", path: request.transcriptPath },
+			metadata: { ...request.metadata, filter_version: FILTER_VERSION },
+			subagents: request.subagents.map((subagent) => ({
+				agentId: subagent.agentId,
+				source: { kind: "file", path: subagent.path },
+			})),
+		};
+	}
+	const { content, subagents, ...metadata } = request;
+	return {
+		main: { content, kind: "text" },
+		metadata: { ...metadata, filter_version: FILTER_VERSION },
+		subagents: (subagents ?? []).map((subagent) => ({
+			agentId: subagent.agentId,
+			source: { content: subagent.content, kind: "text" },
+		})),
+	};
+}
+
+export async function stageFilteredUpload(
+	sources: FilteredUploadSources,
+): Promise<StagedFilteredUpload> {
+	const directory = await createOwnedR2StagingDirectory(
+		R2_UPLOAD_STAGING_DIRECTORY_PREFIX,
+	);
+	try {
+		return await stageSourcesIntoDirectory(sources, directory);
+	} catch (error) {
+		await cleanupOwnedR2StagingDirectory(directory);
+		throw error;
+	}
+}
+
+export async function cleanupStagedUpload(
+	staged: StagedFilteredUpload,
+): Promise<void> {
+	await cleanupOwnedR2StagingDirectory(staged.directory);
+}
+
+async function stageSourcesIntoDirectory(
+	sources: FilteredUploadSources,
+	directory: string,
+): Promise<StagedFilteredUpload> {
+	const main = await stageSource(sources.main, join(directory, "main.jsonl"));
+	const objects: StagedUploadObject[] = [
+		{
+			byteLength: main.byteLength,
+			kind: "main",
+			path: join(directory, "main.jsonl"),
+			sha256: main.sha256,
+		},
+	];
+	let aggregateBytes = main.byteLength;
+	let inputBytes = main.inputBytes;
+	let redactedBytes = main.redactedBytes;
+	let redactions = main.redactions;
+	const sortedSubagents = [...sources.subagents].sort((left, right) =>
+		left.agentId.localeCompare(right.agentId),
+	);
+
+	for (const [index, subagent] of sortedSubagents.entries()) {
+		const path = join(directory, `subagent-${index + 1}.jsonl`);
+		const result = await stageSource(subagent.source, path);
+		aggregateBytes += result.byteLength;
+		inputBytes += result.inputBytes;
+		redactedBytes += result.redactedBytes;
+		redactions = mergeRedactionCounts(redactions, result.redactions);
+		if (result.byteLength === 0) continue;
+		objects.push({
+			agentId: subagent.agentId,
+			byteLength: result.byteLength,
+			kind: "subagent",
+			path,
+			sha256: result.sha256,
+		});
+	}
+
+	return {
+		aggregateBytes,
+		directory,
+		inputBytes,
+		metadata: sources.metadata,
+		objects,
+		redactedBytes,
+		redactions,
+	};
+}
+
+async function stageSource(
+	source: TranscriptSource,
+	destinationPath: string,
+): Promise<FilteredFileResult> {
+	return source.kind === "text"
+		? stageText(source.content, destinationPath)
+		: stageFile(source.path, destinationPath);
+}
+
+async function stageText(
+	content: string,
+	destinationPath: string,
+): Promise<FilteredFileResult> {
+	const filtered = filterSessionTextFields({ content, subagents: undefined });
+	const byteLength = Buffer.byteLength(filtered.content, "utf8");
+	await writeFile(destinationPath, filtered.content, {
+		encoding: "utf8",
+		flag: "wx",
+		mode: 0o600,
+	});
+	return {
+		byteLength,
+		inputBytes: Buffer.byteLength(content, "utf8"),
+		redactedBytes: filtered.redactedBytes,
+		redactions: filtered.counts,
+		sha256: createHash("sha256").update(filtered.content, "utf8").digest("hex"),
+	};
+}
+
+async function stageFile(
+	sourcePath: string,
+	destinationPath: string,
+): Promise<FilteredFileResult> {
+	const input = createReadStream(sourcePath, { highWaterMark: 64 * 1024 });
+	const output = await open(destinationPath, "wx", 0o600);
+	const decoder = new StringDecoder("utf8");
+	const hash = createHash("sha256");
+	let pending = "";
+	let byteLength = 0;
+	let inputBytes = 0;
+	let redactedBytes = 0;
+	let redactions: RedactionCounts = {};
+
+	try {
+		for await (const chunk of input) {
+			if (!(chunk instanceof Uint8Array)) {
+				throw new Error("Transcript stream produced a non-binary chunk");
+			}
+			inputBytes += chunk.byteLength;
+			pending += decoder.write(chunk);
+			let newlineIndex = pending.indexOf("\n");
+			while (newlineIndex >= 0) {
+				const record = pending.slice(0, newlineIndex + 1);
+				pending = pending.slice(newlineIndex + 1);
+				assertRecordWithinLimit(record);
+				const result = await filterAndWriteRecord(record, output, hash);
+				byteLength += result.byteLength;
+				redactedBytes += result.redactedBytes;
+				redactions = mergeRedactionCounts(redactions, result.redactions);
+				newlineIndex = pending.indexOf("\n");
+			}
+			assertRecordWithinLimit(pending);
+		}
+
+		pending += decoder.end();
+		if (pending.length > 0) {
+			assertRecordWithinLimit(pending);
+			const result = await filterAndWriteRecord(pending, output, hash);
+			byteLength += result.byteLength;
+			redactedBytes += result.redactedBytes;
+			redactions = mergeRedactionCounts(redactions, result.redactions);
+		}
+	} finally {
+		await output.close();
+	}
+
+	return {
+		byteLength,
+		inputBytes,
+		redactedBytes,
+		redactions,
+		sha256: hash.digest("hex"),
+	};
+}
+
+async function filterAndWriteRecord(
+	record: string,
+	output: Awaited<ReturnType<typeof open>>,
+	hash: ReturnType<typeof createHash>,
+): Promise<{
+	readonly byteLength: number;
+	readonly redactedBytes: number;
+	readonly redactions: RedactionCounts;
+}> {
+	const filtered = filterSessionTextFields({
+		content: record,
+		subagents: undefined,
+	});
+	await output.writeFile(filtered.content, { encoding: "utf8" });
+	hash.update(filtered.content, "utf8");
+	return {
+		byteLength: Buffer.byteLength(filtered.content, "utf8"),
+		redactedBytes: filtered.redactedBytes,
+		redactions: filtered.counts,
+	};
+}
+
+function assertRecordWithinLimit(record: string): void {
+	const bytes = Buffer.byteLength(record, "utf8");
+	if (bytes > MAX_STREAM_RECORD_BYTES) {
+		throw new Error(
+			`Transcript contains a record larger than ${MAX_STREAM_RECORD_BYTES} bytes; refusing an unbounded secret-filter buffer`,
+		);
+	}
+}
+
+function isFileBackedUploadRequest(
+	request: IngestSessionInput | FileBackedUploadRequest,
+): request is FileBackedUploadRequest {
+	return "kind" in request && request.kind === "file";
+}

--- a/apps/cli/src/lib/r2-ingest-contract.ts
+++ b/apps/cli/src/lib/r2-ingest-contract.ts
@@ -1,0 +1,290 @@
+import type { Client, ORPCError } from "@orpc/client";
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { IngestSessionInput } from "../contracts/index.js";
+import type { RedactionCounts } from "../internal/secret-filter/index.js";
+
+export const R2_INGEST_PROTOCOL = "r2_multipart_v1" as const;
+export const R2_INGEST_PART_SIZE_BYTES = 8 * 1024 * 1024;
+
+export type R2IngestMetadata = Omit<
+	IngestSessionInput,
+	"content" | "subagents"
+>;
+
+interface R2IngestObjectBase {
+	readonly byteLength: number;
+	readonly sha256: string;
+}
+
+export interface R2IngestMainObjectInput extends R2IngestObjectBase {
+	readonly kind: "main";
+}
+
+export interface R2IngestSubagentObjectInput extends R2IngestObjectBase {
+	readonly agentId: string;
+	readonly kind: "subagent";
+}
+
+export type R2IngestObjectInput =
+	| R2IngestMainObjectInput
+	| R2IngestSubagentObjectInput;
+
+export interface R2IngestInitInput extends R2IngestMetadata {
+	readonly objects: readonly R2IngestObjectInput[];
+}
+
+export interface R2IngestUploadPart {
+	readonly byteLength: number;
+	readonly headers: { readonly "Content-Length": string };
+	readonly partNumber: number;
+	readonly uploadUrl: string;
+}
+
+interface R2IngestUploadObjectBase extends R2IngestObjectBase {
+	readonly objectKey: string;
+	readonly parts: readonly R2IngestUploadPart[];
+	readonly uploadId: string;
+}
+
+export interface R2IngestMainUploadObject extends R2IngestUploadObjectBase {
+	readonly kind: "main";
+}
+
+export interface R2IngestSubagentUploadObject extends R2IngestUploadObjectBase {
+	readonly agentId: string;
+	readonly kind: "subagent";
+}
+
+export type R2IngestUploadObject =
+	| R2IngestMainUploadObject
+	| R2IngestSubagentUploadObject;
+
+export interface R2IngestInitOutput {
+	readonly expiresAt: string;
+	readonly jobId: string;
+	readonly objects: readonly R2IngestUploadObject[];
+	readonly partSizeBytes: typeof R2_INGEST_PART_SIZE_BYTES;
+	readonly protocol: typeof R2_INGEST_PROTOCOL;
+}
+
+export interface R2IngestCompletedPart {
+	readonly etag: string;
+	readonly partNumber: number;
+}
+
+export interface R2IngestCompletedObject {
+	readonly objectKey: string;
+	readonly parts: readonly R2IngestCompletedPart[];
+	readonly uploadId: string;
+}
+
+export interface R2IngestCommitInput {
+	readonly jobId: string;
+	readonly objects: readonly R2IngestCompletedObject[];
+}
+
+export interface R2IngestSuccess {
+	readonly success: true;
+	readonly sessionId: string;
+	readonly upgradeHint:
+		| { readonly protocol: typeof R2_INGEST_PROTOCOL }
+		| undefined;
+	readonly redacted: RedactionCounts | undefined;
+	readonly redactedBytes: number | undefined;
+	readonly usageChecksum: string | undefined;
+}
+
+export interface R2IngestCommitOutput {
+	readonly jobId: string;
+	readonly protocol: typeof R2_INGEST_PROTOCOL;
+	readonly result: R2IngestSuccess;
+	readonly status: "completed";
+}
+
+export type R2IngestJobStatus = "pending" | "running" | "completed" | "failed";
+
+export interface R2IngestStatusOutput {
+	readonly attempts: number;
+	readonly availableAt: string;
+	readonly error: { readonly code: string; readonly message: string } | null;
+	readonly jobId: string;
+	readonly leaseExpiresAt: string | null;
+	readonly protocol: typeof R2_INGEST_PROTOCOL;
+	readonly result: R2IngestSuccess | null;
+	readonly status: R2IngestJobStatus;
+	readonly updatedAt: string;
+}
+
+type R2Procedure<TInput, TOutput> = Client<
+	Record<never, never>,
+	TInput,
+	TOutput,
+	ORPCError<string, unknown>
+>;
+
+export type R2IngestRpcClient = {
+	readonly ingest: {
+		readonly commit: R2Procedure<R2IngestCommitInput, R2IngestCommitOutput>;
+		readonly init: R2Procedure<R2IngestInitInput, R2IngestInitOutput>;
+		readonly status: R2Procedure<
+			{ readonly jobId: string },
+			R2IngestStatusOutput
+		>;
+	};
+};
+
+export function createR2IngestRpcClient(config: {
+	readonly authType: "api-key" | "bearer";
+	readonly endpoint: URL;
+	readonly token: string;
+}): R2IngestRpcClient {
+	const headers =
+		config.authType === "api-key"
+			? { "x-api-key": config.token }
+			: { Authorization: `Bearer ${config.token}` };
+	const link = new RPCLink({ headers, url: config.endpoint });
+	return createORPCClient<R2IngestRpcClient>(link);
+}
+
+export function isR2IngestInitOutput(
+	value: unknown,
+): value is R2IngestInitOutput {
+	return (
+		isRecord(value) &&
+		value.protocol === R2_INGEST_PROTOCOL &&
+		value.partSizeBytes === R2_INGEST_PART_SIZE_BYTES &&
+		isNonEmptyString(value.expiresAt) &&
+		isNonEmptyString(value.jobId) &&
+		Array.isArray(value.objects) &&
+		value.objects.length > 0 &&
+		value.objects.every(isR2IngestUploadObject)
+	);
+}
+
+export function isR2IngestCommitOutput(
+	value: unknown,
+): value is R2IngestCommitOutput {
+	return (
+		isRecord(value) &&
+		value.protocol === R2_INGEST_PROTOCOL &&
+		value.status === "completed" &&
+		isNonEmptyString(value.jobId) &&
+		isR2IngestSuccess(value.result)
+	);
+}
+
+export function isR2IngestStatusOutput(
+	value: unknown,
+): value is R2IngestStatusOutput {
+	return (
+		isRecord(value) &&
+		value.protocol === R2_INGEST_PROTOCOL &&
+		isNonEmptyString(value.jobId) &&
+		isNonNegativeInteger(value.attempts) &&
+		isNonEmptyString(value.availableAt) &&
+		isNonEmptyString(value.updatedAt) &&
+		(value.leaseExpiresAt === null || isNonEmptyString(value.leaseExpiresAt)) &&
+		isR2IngestJobStatus(value.status) &&
+		(value.error === null || isR2IngestStatusError(value.error)) &&
+		(value.result === null || isR2IngestSuccess(value.result))
+	);
+}
+
+export function hasR2IngestUpgradeHint(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		isRecord(value.upgradeHint) &&
+		value.upgradeHint.protocol === R2_INGEST_PROTOCOL
+	);
+}
+
+function isR2IngestUploadObject(value: unknown): value is R2IngestUploadObject {
+	if (
+		!isRecord(value) ||
+		(value.kind !== "main" && value.kind !== "subagent") ||
+		!isPositiveInteger(value.byteLength) ||
+		!isSha256(value.sha256) ||
+		!isNonEmptyString(value.objectKey) ||
+		!isNonEmptyString(value.uploadId) ||
+		!Array.isArray(value.parts) ||
+		value.parts.length === 0 ||
+		!value.parts.every(isR2IngestUploadPart)
+	) {
+		return false;
+	}
+	return value.kind === "main" || isNonEmptyString(value.agentId);
+}
+
+function isR2IngestUploadPart(value: unknown): value is R2IngestUploadPart {
+	return (
+		isRecord(value) &&
+		isPositiveInteger(value.byteLength) &&
+		isPositiveInteger(value.partNumber) &&
+		isNonEmptyString(value.uploadUrl) &&
+		isRecord(value.headers) &&
+		typeof value.headers["Content-Length"] === "string" &&
+		/^[1-9][0-9]*$/u.test(value.headers["Content-Length"])
+	);
+}
+
+function isR2IngestSuccess(value: unknown): value is R2IngestSuccess {
+	if (
+		!isRecord(value) ||
+		value.success !== true ||
+		!isNonEmptyString(value.sessionId) ||
+		(value.upgradeHint !== undefined &&
+			(!isRecord(value.upgradeHint) ||
+				value.upgradeHint.protocol !== R2_INGEST_PROTOCOL)) ||
+		(value.redacted !== undefined && !isRedactionCounts(value.redacted)) ||
+		(value.redactedBytes !== undefined &&
+			!isNonNegativeInteger(value.redactedBytes)) ||
+		(value.usageChecksum !== undefined && !isSha256(value.usageChecksum))
+	) {
+		return false;
+	}
+	return true;
+}
+
+function isR2IngestStatusError(
+	value: unknown,
+): value is { readonly code: string; readonly message: string } {
+	return (
+		isRecord(value) &&
+		isNonEmptyString(value.code) &&
+		isNonEmptyString(value.message)
+	);
+}
+
+function isR2IngestJobStatus(value: unknown): value is R2IngestJobStatus {
+	return (
+		value === "pending" ||
+		value === "running" ||
+		value === "completed" ||
+		value === "failed"
+	);
+}
+
+function isRedactionCounts(value: unknown): value is RedactionCounts {
+	return isRecord(value) && Object.values(value).every(isNonNegativeInteger);
+}
+
+function isSha256(value: unknown): value is string {
+	return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return Number.isSafeInteger(value) && typeof value === "number" && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return Number.isSafeInteger(value) && typeof value === "number" && value >= 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}

--- a/apps/cli/src/lib/r2-multipart-upload.ts
+++ b/apps/cli/src/lib/r2-multipart-upload.ts
@@ -1,0 +1,509 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { type FileHandle, open, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+	R2IngestCompletedObject,
+	R2IngestUploadObject,
+	R2IngestUploadPart,
+} from "./r2-ingest-contract.js";
+import {
+	cleanupOwnedR2StagingDirectory,
+	createOwnedR2StagingDirectory,
+	R2_PART_STAGING_DIRECTORY_PREFIX,
+} from "./r2-staging-cleanup.js";
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 500;
+const STREAM_CHUNK_BYTES = 64 * 1024;
+
+export interface R2MultipartProgress {
+	readonly attempt: number;
+	readonly objectBytesUploaded: number;
+	readonly objectKey: string;
+	readonly partBytesUploaded: number;
+	readonly partNumber: number;
+	readonly totalObjectBytes: number;
+	readonly totalPartBytes: number;
+}
+
+export interface R2MultipartRetry {
+	readonly attempt: number;
+	readonly error: string;
+	readonly maxAttempts: number;
+	readonly objectKey: string;
+	readonly partNumber: number;
+}
+
+export interface R2MultipartUploadSource {
+	readonly path: string;
+	readonly upload: R2IngestUploadObject;
+}
+
+export interface R2MultipartUploadOptions {
+	readonly baseDelayMs: number | undefined;
+	readonly fetch: typeof globalThis.fetch | undefined;
+	readonly maxAttempts: number | undefined;
+	readonly onProgress: ((progress: R2MultipartProgress) => void) | undefined;
+	readonly onRetry: ((retry: R2MultipartRetry) => void) | undefined;
+	readonly sources: readonly R2MultipartUploadSource[];
+}
+
+export interface R2MultipartUploadResult {
+	readonly attempts: number;
+	readonly objects: readonly R2IngestCompletedObject[];
+}
+
+export interface FileDigest {
+	readonly byteLength: number;
+	readonly sha256: string;
+}
+
+export interface FilePartRange {
+	readonly byteLength: number;
+	readonly end: number;
+	readonly partNumber: number;
+	readonly start: number;
+}
+
+interface StreamingRequestInit extends RequestInit {
+	readonly duplex: "half";
+}
+
+export class R2MultipartUploadError extends Error {
+	readonly retryable: boolean;
+	readonly status: number | undefined;
+
+	constructor(
+		message: string,
+		options: {
+			readonly retryable: boolean;
+			readonly status: number | undefined;
+		},
+	) {
+		super(message);
+		this.name = "R2MultipartUploadError";
+		this.retryable = options.retryable;
+		this.status = options.status;
+	}
+}
+
+export async function uploadR2MultipartObjects(
+	options: R2MultipartUploadOptions,
+): Promise<R2MultipartUploadResult> {
+	const completedObjects: R2IngestCompletedObject[] = [];
+	let attempts = 1;
+	for (const source of options.sources) {
+		const result = await uploadObject(source, options);
+		attempts = Math.max(attempts, result.attempts);
+		completedObjects.push(result.completed);
+	}
+	return { attempts, objects: completedObjects };
+}
+
+export async function inspectUploadFile(path: string): Promise<FileDigest> {
+	const hash = createHash("sha256");
+	let byteLength = 0;
+	for await (const chunk of createReadStream(path, {
+		highWaterMark: STREAM_CHUNK_BYTES,
+	})) {
+		if (!(chunk instanceof Uint8Array)) {
+			throw new Error("Upload file stream produced a non-binary chunk");
+		}
+		hash.update(chunk);
+		byteLength += chunk.byteLength;
+	}
+	return { byteLength, sha256: hash.digest("hex") };
+}
+
+export function buildFilePartRanges(
+	byteLength: number,
+	partSizeBytes: number,
+): readonly FilePartRange[] {
+	if (!Number.isSafeInteger(byteLength) || byteLength <= 0) {
+		throw new Error("Upload byte length must be a positive safe integer");
+	}
+	if (!Number.isSafeInteger(partSizeBytes) || partSizeBytes <= 0) {
+		throw new Error("Upload part size must be a positive safe integer");
+	}
+	const partCount = Math.ceil(byteLength / partSizeBytes);
+	return Array.from({ length: partCount }, (_, index) => {
+		const start = index * partSizeBytes;
+		const partByteLength = Math.min(partSizeBytes, byteLength - start);
+		return {
+			byteLength: partByteLength,
+			end: start + partByteLength - 1,
+			partNumber: index + 1,
+			start,
+		};
+	});
+}
+
+async function uploadObject(
+	source: R2MultipartUploadSource,
+	options: R2MultipartUploadOptions,
+): Promise<{
+	readonly attempts: number;
+	readonly completed: R2IngestCompletedObject;
+}> {
+	await assertUploadObjectMatchesFile(source);
+	assertUploadPartManifest(source.upload);
+	const completedParts = [];
+	let completedBytes = 0;
+	let attempts = 1;
+	for (const part of source.upload.parts) {
+		const uploaded = await uploadPart({
+			baseDelayMs: options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+			completedBytes,
+			fetch: options.fetch ?? globalThis.fetch,
+			maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+			onProgress: options.onProgress,
+			onRetry: options.onRetry,
+			part,
+			path: source.path,
+			totalObjectBytes: source.upload.byteLength,
+			objectKey: source.upload.objectKey,
+		});
+		attempts = Math.max(attempts, uploaded.attempts);
+		completedBytes += part.byteLength;
+		completedParts.push({ etag: uploaded.etag, partNumber: part.partNumber });
+	}
+	return {
+		attempts,
+		completed: {
+			objectKey: source.upload.objectKey,
+			parts: completedParts,
+			uploadId: source.upload.uploadId,
+		},
+	};
+}
+
+async function uploadPart(input: {
+	readonly baseDelayMs: number;
+	readonly completedBytes: number;
+	readonly fetch: typeof globalThis.fetch;
+	readonly maxAttempts: number;
+	readonly objectKey: string;
+	readonly onProgress: ((progress: R2MultipartProgress) => void) | undefined;
+	readonly onRetry: ((retry: R2MultipartRetry) => void) | undefined;
+	readonly part: R2IngestUploadPart;
+	readonly path: string;
+	readonly totalObjectBytes: number;
+}): Promise<{ readonly attempts: number; readonly etag: string }> {
+	const start = input.completedBytes;
+	for (let attempt = 1; attempt <= input.maxAttempts; attempt += 1) {
+		try {
+			const etag = await putFilePart({ ...input, attempt, start });
+			return { attempts: attempt, etag };
+		} catch (error) {
+			const uploadError = toMultipartUploadError(error);
+			if (!uploadError.retryable || attempt === input.maxAttempts) {
+				throw uploadError;
+			}
+			input.onRetry?.({
+				attempt,
+				error: uploadError.message,
+				maxAttempts: input.maxAttempts,
+				objectKey: input.objectKey,
+				partNumber: input.part.partNumber,
+			});
+			await delay(input.baseDelayMs * 2 ** (attempt - 1));
+		}
+	}
+	throw new R2MultipartUploadError("Multipart part retries were exhausted", {
+		retryable: true,
+		status: undefined,
+	});
+}
+
+async function putFilePart(input: {
+	readonly attempt: number;
+	readonly completedBytes: number;
+	readonly fetch: typeof globalThis.fetch;
+	readonly objectKey: string;
+	readonly onProgress: ((progress: R2MultipartProgress) => void) | undefined;
+	readonly part: R2IngestUploadPart;
+	readonly path: string;
+	readonly start: number;
+	readonly totalObjectBytes: number;
+}): Promise<string> {
+	let partBytesUploaded = 0;
+	const reportChunk = (chunkBytes: number) => {
+		partBytesUploaded += chunkBytes;
+		input.onProgress?.({
+			attempt: input.attempt,
+			objectBytesUploaded: input.completedBytes + partBytesUploaded,
+			objectKey: input.objectKey,
+			partBytesUploaded,
+			partNumber: input.part.partNumber,
+			totalObjectBytes: input.totalObjectBytes,
+			totalPartBytes: input.part.byteLength,
+		});
+	};
+	const body = await createFilePartBody(
+		input.path,
+		input.start,
+		input.part.byteLength,
+		reportChunk,
+	);
+	const request: StreamingRequestInit = {
+		body: body.value,
+		duplex: "half",
+		headers: input.part.headers,
+		method: "PUT",
+	};
+	let response: Response;
+	try {
+		response = await input.fetch(input.part.uploadUrl, request);
+	} finally {
+		await body.cleanup();
+	}
+	if (!body.reportsStreamingProgress) {
+		reportChunk(input.part.byteLength);
+	}
+	if (!response.ok) {
+		await response.body?.cancel();
+		throw new R2MultipartUploadError(
+			`R2 part upload failed with ${response.status} ${response.statusText}`,
+			{
+				retryable: isTransientHttpStatus(response.status),
+				status: response.status,
+			},
+		);
+	}
+	const etag = response.headers.get("etag")?.trim();
+	await response.body?.cancel();
+	if (!etag) {
+		throw new R2MultipartUploadError(
+			"R2 part upload succeeded without an ETag response header",
+			{ retryable: false, status: response.status },
+		);
+	}
+	return etag;
+}
+
+async function createFilePartBody(
+	path: string,
+	start: number,
+	byteLength: number,
+	onChunk: (byteLength: number) => void,
+): Promise<{
+	readonly cleanup: () => Promise<void>;
+	readonly reportsStreamingProgress: boolean;
+	readonly value: NonNullable<RequestInit["body"]>;
+}> {
+	if (hasBunFileFactory()) {
+		const materialized = await materializeFilePart(path, start, byteLength);
+		const bunFile = getBunFile(materialized.path);
+		if (!bunFile) {
+			await materialized.cleanup();
+			throw new Error("Bun.file did not return a Blob for an upload part");
+		}
+		return {
+			cleanup: materialized.cleanup,
+			reportsStreamingProgress: false,
+			value: bunFile,
+		};
+	}
+	return {
+		cleanup: async () => {},
+		reportsStreamingProgress: true,
+		value: createFileRangeStream(path, start, byteLength, onChunk),
+	};
+}
+
+function hasBunFileFactory(): boolean {
+	const runtime: unknown = Reflect.get(globalThis, "Bun");
+	return isRecord(runtime) && typeof runtime.file === "function";
+}
+
+function getBunFile(path: string): Blob | null {
+	const runtime: unknown = Reflect.get(globalThis, "Bun");
+	if (!isRecord(runtime)) return null;
+	const fileFactory = runtime.file;
+	if (typeof fileFactory !== "function") return null;
+	const file: unknown = Reflect.apply(fileFactory, runtime, [path]);
+	return file instanceof Blob ? file : null;
+}
+
+async function materializeFilePart(
+	path: string,
+	start: number,
+	byteLength: number,
+): Promise<{ readonly cleanup: () => Promise<void>; readonly path: string }> {
+	const directory = await createOwnedR2StagingDirectory(
+		R2_PART_STAGING_DIRECTORY_PREFIX,
+	);
+	const partPath = join(directory, "part.bin");
+	let source: FileHandle | undefined;
+	let destination: FileHandle | undefined;
+	try {
+		source = await open(path, "r");
+		destination = await open(partPath, "wx", 0o600);
+		let copiedBytes = 0;
+		while (copiedBytes < byteLength) {
+			const buffer = Buffer.allocUnsafe(
+				Math.min(STREAM_CHUNK_BYTES, byteLength - copiedBytes),
+			);
+			const { bytesRead } = await source.read(
+				buffer,
+				0,
+				buffer.byteLength,
+				start + copiedBytes,
+			);
+			if (bytesRead === 0) {
+				throw new Error("Upload file ended before the signed part length");
+			}
+			await writeCompleteBuffer(destination, buffer.subarray(0, bytesRead));
+			copiedBytes += bytesRead;
+		}
+	} catch (error) {
+		await closeFiles(source, destination);
+		await cleanupOwnedR2StagingDirectory(directory);
+		throw error;
+	}
+	await closeFiles(source, destination);
+	return {
+		cleanup: () => cleanupOwnedR2StagingDirectory(directory),
+		path: partPath,
+	};
+}
+
+async function closeFiles(
+	...files: readonly (FileHandle | undefined)[]
+): Promise<void> {
+	await Promise.allSettled(files.map((file) => file?.close()));
+}
+
+async function writeCompleteBuffer(
+	file: FileHandle,
+	buffer: Uint8Array,
+): Promise<void> {
+	let offset = 0;
+	while (offset < buffer.byteLength) {
+		const { bytesWritten } = await file.write(
+			buffer,
+			offset,
+			buffer.byteLength - offset,
+		);
+		if (bytesWritten === 0) {
+			throw new Error("Could not write the complete temporary upload part");
+		}
+		offset += bytesWritten;
+	}
+}
+
+function createFileRangeStream(
+	path: string,
+	start: number,
+	byteLength: number,
+	onChunk: (byteLength: number) => void,
+): ReadableStream<Uint8Array> {
+	let file: FileHandle | undefined;
+	let offset = 0;
+	let closed = false;
+
+	async function closeFile(): Promise<void> {
+		if (closed) return;
+		closed = true;
+		await file?.close();
+	}
+
+	return new ReadableStream<Uint8Array>({
+		async cancel() {
+			await closeFile();
+		},
+		async pull(controller) {
+			try {
+				if (!file) file = await open(path, "r");
+				const remaining = byteLength - offset;
+				if (remaining === 0) {
+					await closeFile();
+					controller.close();
+					return;
+				}
+				const buffer = Buffer.allocUnsafe(
+					Math.min(STREAM_CHUNK_BYTES, remaining),
+				);
+				const { bytesRead } = await file.read(
+					buffer,
+					0,
+					buffer.byteLength,
+					start + offset,
+				);
+				if (bytesRead === 0) {
+					throw new Error("Upload file ended before the signed part length");
+				}
+				offset += bytesRead;
+				onChunk(bytesRead);
+				controller.enqueue(buffer.subarray(0, bytesRead));
+				if (offset === byteLength) {
+					await closeFile();
+					controller.close();
+				}
+			} catch (error) {
+				await closeFile();
+				controller.error(error);
+			}
+		},
+	});
+}
+
+async function assertUploadObjectMatchesFile(
+	source: R2MultipartUploadSource,
+): Promise<void> {
+	const file = await stat(source.path);
+	if (!file.isFile()) {
+		throw new Error(`R2 upload source is not a regular file: ${source.path}`);
+	}
+	if (file.size !== source.upload.byteLength) {
+		throw new Error(
+			`R2 upload source size changed: expected ${source.upload.byteLength} bytes, found ${file.size}`,
+		);
+	}
+}
+
+function assertUploadPartManifest(upload: R2IngestUploadObject): void {
+	let totalBytes = 0;
+	for (const [index, part] of upload.parts.entries()) {
+		const expectedPartNumber = index + 1;
+		if (part.partNumber !== expectedPartNumber) {
+			throw new Error(
+				`R2 upload part numbers must be sequential from 1; received ${part.partNumber}`,
+			);
+		}
+		if (part.headers["Content-Length"] !== part.byteLength.toString()) {
+			throw new Error(
+				`R2 signed Content-Length does not match part ${part.partNumber}`,
+			);
+		}
+		totalBytes += part.byteLength;
+	}
+	if (totalBytes !== upload.byteLength) {
+		throw new Error(
+			`R2 part manifest totals ${totalBytes} bytes, expected ${upload.byteLength}`,
+		);
+	}
+}
+
+function toMultipartUploadError(error: unknown): R2MultipartUploadError {
+	if (error instanceof R2MultipartUploadError) return error;
+	const message = error instanceof Error ? error.message : "network failure";
+	return new R2MultipartUploadError(
+		`R2 part upload failed before a response: ${message}`,
+		{ retryable: true, status: undefined },
+	);
+}
+
+function isTransientHttpStatus(status: number): boolean {
+	return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+async function delay(milliseconds: number): Promise<void> {
+	if (milliseconds <= 0) return;
+	await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/apps/cli/src/lib/r2-staging-cleanup.ts
+++ b/apps/cli/src/lib/r2-staging-cleanup.ts
@@ -1,0 +1,133 @@
+import { type Dirent, rmSync } from "node:fs";
+import { lstat, mkdtemp, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export const R2_UPLOAD_STAGING_DIRECTORY_PREFIX = "opaline-r2-upload-";
+export const R2_PART_STAGING_DIRECTORY_PREFIX = "opaline-r2-part-";
+export const R2_STAGING_STALE_AGE_MS = 24 * 60 * 60 * 1_000;
+
+const R2_STAGING_DIRECTORY_PREFIXES = [
+	R2_UPLOAD_STAGING_DIRECTORY_PREFIX,
+	R2_PART_STAGING_DIRECTORY_PREFIX,
+] as const;
+const HANDLED_SIGNALS = ["SIGINT", "SIGTERM"] as const;
+const activeStagingDirectories = new Set<string>();
+const signalHandlers = new Map<HandledSignal, () => void>();
+let initialized = false;
+
+type HandledSignal = (typeof HANDLED_SIGNALS)[number];
+
+export async function initializeR2StagingCleanup(): Promise<void> {
+	if (initialized) return;
+	initialized = true;
+	installCleanupHandlers();
+	try {
+		await scavengeStaleR2StagingDirectories({
+			ownerUid: getCurrentUid(),
+			staleBeforeMs: Date.now() - R2_STAGING_STALE_AGE_MS,
+			temporaryDirectory: tmpdir(),
+		});
+	} catch {
+		// Startup cleanup is best effort and must not prevent the CLI from running.
+	}
+}
+
+export async function createOwnedR2StagingDirectory(
+	prefix:
+		| typeof R2_UPLOAD_STAGING_DIRECTORY_PREFIX
+		| typeof R2_PART_STAGING_DIRECTORY_PREFIX,
+): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), prefix));
+	activeStagingDirectories.add(directory);
+	return directory;
+}
+
+export async function cleanupOwnedR2StagingDirectory(
+	directory: string,
+): Promise<void> {
+	await rm(directory, { force: true, recursive: true });
+	activeStagingDirectories.delete(directory);
+}
+
+export async function scavengeStaleR2StagingDirectories(options: {
+	readonly ownerUid: number | undefined;
+	readonly staleBeforeMs: number;
+	readonly temporaryDirectory: string;
+}): Promise<readonly string[]> {
+	if (options.ownerUid === undefined) return [];
+	let entries: Dirent<string>[];
+	try {
+		entries = await readdir(options.temporaryDirectory, {
+			encoding: "utf8",
+			withFileTypes: true,
+		});
+	} catch {
+		return [];
+	}
+
+	const removed: string[] = [];
+	for (const entry of entries) {
+		if (!entry.isDirectory() || !hasOwnedStagingPrefix(entry.name)) continue;
+		const directory = join(options.temporaryDirectory, entry.name);
+		if (activeStagingDirectories.has(directory)) continue;
+		try {
+			const metadata = await lstat(directory);
+			if (
+				!metadata.isDirectory() ||
+				metadata.uid !== options.ownerUid ||
+				metadata.mtimeMs >= options.staleBeforeMs
+			) {
+				continue;
+			}
+			await rm(directory, { force: true, recursive: true });
+			removed.push(directory);
+		} catch {
+			// A concurrent process may remove or replace the directory while scanning.
+		}
+	}
+	return removed;
+}
+
+function installCleanupHandlers(): void {
+	for (const signal of HANDLED_SIGNALS) {
+		const handler = () => handleSignal(signal);
+		signalHandlers.set(signal, handler);
+		process.once(signal, handler);
+	}
+	process.once("exit", cleanupActiveStagingDirectoriesSync);
+}
+
+function handleSignal(signal: HandledSignal): void {
+	cleanupActiveStagingDirectoriesSync();
+	for (const [registeredSignal, handler] of signalHandlers) {
+		process.removeListener(registeredSignal, handler);
+	}
+	signalHandlers.clear();
+	try {
+		process.kill(process.pid, signal);
+	} catch {
+		process.exit(signal === "SIGINT" ? 130 : 143);
+	}
+}
+
+function cleanupActiveStagingDirectoriesSync(): void {
+	for (const directory of activeStagingDirectories) {
+		try {
+			rmSync(directory, { force: true, recursive: true });
+		} catch {
+			// Signal and exit cleanup cannot safely surface filesystem failures.
+		}
+	}
+	activeStagingDirectories.clear();
+}
+
+function hasOwnedStagingPrefix(name: string): boolean {
+	return R2_STAGING_DIRECTORY_PREFIXES.some((prefix) =>
+		name.startsWith(prefix),
+	);
+}
+
+function getCurrentUid(): number | undefined {
+	return typeof process.getuid === "function" ? process.getuid() : undefined;
+}

--- a/apps/cli/src/lib/r2-upload-capability.ts
+++ b/apps/cli/src/lib/r2-upload-capability.ts
@@ -1,0 +1,72 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { getConfigDir, writePrivateFile } from "./local-state.js";
+import { R2_INGEST_PROTOCOL } from "./r2-ingest-contract.js";
+
+const advertisedEndpoints = new Set<string>();
+
+export function hasAdvertisedR2UploadCapability(
+	endpoint: URL,
+	authType: "api-key" | "bearer",
+	token: string,
+): boolean {
+	const key = getCapabilityKey(endpoint, authType, token);
+	if (advertisedEndpoints.has(key)) return true;
+	try {
+		const path = getCapabilityPath(key);
+		if (!existsSync(path)) return false;
+		if (readFileSync(path, "utf8").trim() !== R2_INGEST_PROTOCOL) return false;
+		advertisedEndpoints.add(key);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function rememberR2UploadCapability(
+	endpoint: URL,
+	authType: "api-key" | "bearer",
+	token: string,
+): Promise<void> {
+	const key = getCapabilityKey(endpoint, authType, token);
+	advertisedEndpoints.add(key);
+	try {
+		await writePrivateFile(
+			getCapabilityPath(key),
+			`${R2_INGEST_PROTOCOL}\n`,
+			getConfigDir(),
+		);
+	} catch {
+		// Capability persistence is an optimization; in-memory use still works.
+	}
+}
+
+export async function forgetR2UploadCapability(
+	endpoint: URL,
+	authType: "api-key" | "bearer",
+	token: string,
+): Promise<void> {
+	const key = getCapabilityKey(endpoint, authType, token);
+	advertisedEndpoints.delete(key);
+	try {
+		await rm(getCapabilityPath(key), { force: true });
+	} catch {
+		// A stale cache entry only causes another safe init/fallback attempt.
+	}
+}
+
+function getCapabilityKey(
+	endpoint: URL,
+	authType: "api-key" | "bearer",
+	token: string,
+): string {
+	return createHash("sha256")
+		.update(`${endpoint.href}\u0000${authType}\u0000${token}`, "utf8")
+		.digest("hex");
+}
+
+function getCapabilityPath(key: string): string {
+	return join(getConfigDir(), "upload-capabilities", `${key}.txt`);
+}

--- a/apps/cli/src/lib/r2-upload-flow.ts
+++ b/apps/cli/src/lib/r2-upload-flow.ts
@@ -1,0 +1,385 @@
+import { ORPCError } from "@orpc/client";
+import type { IngestSessionInput } from "../contracts/index.js";
+import type { FileBackedUploadRequest } from "../internal/agent-adapters/index.js";
+import {
+	getRedactionBudgetAnomaly,
+	mergeRedactionCounts,
+	type RedactionBudgetAnomaly,
+	type RedactionCounts,
+} from "../internal/secret-filter/index.js";
+import {
+	cleanupStagedUpload,
+	createFilteredUploadSources,
+	type StagedFilteredUpload,
+	type StagedUploadObject,
+	stageFilteredUpload,
+} from "./filtered-upload-staging.js";
+import {
+	createR2IngestRpcClient,
+	isR2IngestCommitOutput,
+	isR2IngestInitOutput,
+	isR2IngestStatusOutput,
+	type R2IngestCommitInput,
+	type R2IngestInitInput,
+	type R2IngestSuccess,
+	type R2IngestUploadObject,
+} from "./r2-ingest-contract.js";
+import {
+	type R2MultipartProgress,
+	R2MultipartUploadError,
+	uploadR2MultipartObjects,
+} from "./r2-multipart-upload.js";
+
+const RPC_MAX_ATTEMPTS = 3;
+const RPC_BASE_DELAY_MS = 500;
+const STATUS_MAX_POLLS = 20;
+const STATUS_POLL_INTERVAL_MS = 500;
+
+export interface R2UploadFlowConfig {
+	readonly authType: "api-key" | "bearer";
+	readonly endpoint: URL;
+	readonly maxAggregateBytes: number;
+	readonly multipartBaseDelayMs: number | undefined;
+	readonly onProgress: ((progress: R2MultipartProgress) => void) | undefined;
+	readonly onRetry:
+		| ((attempt: number, maxAttempts: number, error: string) => void)
+		| undefined;
+	readonly statusPollIntervalMs: number | undefined;
+	readonly token: string;
+}
+
+export type R2UploadFlowResult =
+	| {
+			readonly actualBytes: number;
+			readonly maxBytes: number;
+			readonly status: "too-large";
+	  }
+	| {
+			readonly status: "empty-main";
+	  }
+	| {
+			readonly anomaly: RedactionBudgetAnomaly;
+			readonly status: "redaction-budget";
+	  }
+	| {
+			readonly attempts: number;
+			readonly redactedBytes: number;
+			readonly redactions: RedactionCounts;
+			readonly result: R2IngestSuccess;
+			readonly status: "success";
+	  };
+
+export class R2IngestInitError extends Error {
+	readonly causeValue: unknown;
+	readonly retryable: boolean;
+
+	constructor(causeValue: unknown, retryable: boolean) {
+		const detail = causeValue instanceof Error ? causeValue.message : "unknown";
+		super(`Could not initialize direct R2 upload: ${detail}`);
+		this.name = "R2IngestInitError";
+		this.causeValue = causeValue;
+		this.retryable = retryable;
+	}
+}
+
+export class R2IngestFlowError extends Error {
+	readonly retryable: boolean;
+
+	constructor(message: string, retryable: boolean) {
+		super(message);
+		this.name = "R2IngestFlowError";
+		this.retryable = retryable;
+	}
+}
+
+export async function uploadSessionViaR2(
+	request: IngestSessionInput | FileBackedUploadRequest,
+	config: R2UploadFlowConfig,
+): Promise<R2UploadFlowResult> {
+	const staged = await stageFilteredUpload(
+		createFilteredUploadSources(request),
+	);
+	try {
+		const preflight = getPreflightFailure(staged, config.maxAggregateBytes);
+		if (preflight) return preflight;
+		return await uploadStagedSession(staged, config);
+	} finally {
+		await cleanupStagedUpload(staged);
+	}
+}
+
+export function isR2InitUnsupported(error: unknown): boolean {
+	if (!(error instanceof R2IngestInitError)) return false;
+	const cause = error.causeValue;
+	return (
+		cause instanceof ORPCError &&
+		(cause.status === 404 ||
+			cause.status === 405 ||
+			cause.status === 501 ||
+			cause.code === "R2_INGEST_DISABLED")
+	);
+}
+
+function getPreflightFailure(
+	staged: StagedFilteredUpload,
+	maxAggregateBytes: number,
+): Exclude<R2UploadFlowResult, { readonly status: "success" }> | null {
+	const main = staged.objects.find((object) => object.kind === "main");
+	if (!main || main.byteLength === 0) return { status: "empty-main" };
+	const anomaly = getRedactionBudgetAnomaly(
+		staged.redactedBytes,
+		staged.inputBytes,
+		staged.redactions,
+	);
+	if (anomaly) return { anomaly, status: "redaction-budget" };
+	if (staged.aggregateBytes > maxAggregateBytes) {
+		return {
+			actualBytes: staged.aggregateBytes,
+			maxBytes: maxAggregateBytes,
+			status: "too-large",
+		};
+	}
+	return null;
+}
+
+async function uploadStagedSession(
+	staged: StagedFilteredUpload,
+	config: R2UploadFlowConfig,
+): Promise<Extract<R2UploadFlowResult, { readonly status: "success" }>> {
+	const client = createR2IngestRpcClient(config);
+	let initCall: Awaited<ReturnType<typeof callRpcWithRetry>>;
+	try {
+		initCall = await callRpcWithRetry(
+			() => client.ingest.init(buildInitInput(staged)),
+			config.onRetry,
+		);
+	} catch (error) {
+		throw new R2IngestInitError(error, isRetryableRpcError(error));
+	}
+	if (!isR2IngestInitOutput(initCall.value)) {
+		throw new R2IngestInitError(
+			new Error("Opaline API returned an invalid R2 init response"),
+			false,
+		);
+	}
+	const sources = matchUploadSources(staged.objects, initCall.value.objects);
+	const multipart = await uploadR2MultipartObjects({
+		baseDelayMs: config.multipartBaseDelayMs,
+		fetch: undefined,
+		maxAttempts: RPC_MAX_ATTEMPTS,
+		onProgress: config.onProgress,
+		onRetry: config.onRetry
+			? (retry) =>
+					config.onRetry?.(retry.attempt, retry.maxAttempts, retry.error)
+			: undefined,
+		sources,
+	});
+	const commitInput: R2IngestCommitInput = {
+		jobId: initCall.value.jobId,
+		objects: multipart.objects,
+	};
+	const commitCall = await callRpcWithRetry(
+		() => client.ingest.commit(commitInput),
+		config.onRetry,
+	);
+	if (!isR2IngestCommitOutput(commitCall.value)) {
+		throw new R2IngestFlowError(
+			"Opaline API returned an invalid R2 commit response",
+			false,
+		);
+	}
+	if (commitCall.value.jobId !== initCall.value.jobId) {
+		throw new R2IngestFlowError(
+			"Opaline API returned an R2 commit response for a different job",
+			false,
+		);
+	}
+	const statusCall = await pollJobStatus(client, initCall.value.jobId, config);
+	const serverResult = statusCall.result ?? commitCall.value.result;
+	return {
+		attempts: Math.max(
+			initCall.attempts,
+			multipart.attempts,
+			commitCall.attempts,
+			statusCall.attempts,
+		),
+		redactedBytes: staged.redactedBytes + (serverResult.redactedBytes ?? 0),
+		redactions: mergeRedactionCounts(
+			staged.redactions,
+			serverResult.redacted ?? {},
+		),
+		result: serverResult,
+		status: "success",
+	};
+}
+
+async function pollJobStatus(
+	client: ReturnType<typeof createR2IngestRpcClient>,
+	jobId: string,
+	config: R2UploadFlowConfig,
+): Promise<{
+	readonly attempts: number;
+	readonly result: R2IngestSuccess | null;
+}> {
+	let maxAttempts = 1;
+	for (let poll = 0; poll < STATUS_MAX_POLLS; poll += 1) {
+		const statusCall = await callRpcWithRetry(
+			() => client.ingest.status({ jobId }),
+			config.onRetry,
+		);
+		maxAttempts = Math.max(maxAttempts, statusCall.attempts);
+		if (!isR2IngestStatusOutput(statusCall.value)) {
+			throw new R2IngestFlowError(
+				"Opaline API returned an invalid R2 status response",
+				false,
+			);
+		}
+		if (statusCall.value.jobId !== jobId) {
+			throw new R2IngestFlowError(
+				"Opaline API returned an R2 status response for a different job",
+				false,
+			);
+		}
+		if (statusCall.value.status === "completed") {
+			return { attempts: maxAttempts, result: statusCall.value.result };
+		}
+		if (statusCall.value.status === "failed") {
+			const detail =
+				statusCall.value.error?.message ?? "unknown processing error";
+			throw new R2IngestFlowError(
+				`R2 ingest job failed after upload: ${detail}`,
+				false,
+			);
+		}
+		await delay(config.statusPollIntervalMs ?? STATUS_POLL_INTERVAL_MS);
+	}
+	throw new R2IngestFlowError(
+		"R2 ingest job did not finish within the local status polling window",
+		true,
+	);
+}
+
+function buildInitInput(staged: StagedFilteredUpload): R2IngestInitInput {
+	return {
+		...staged.metadata,
+		objects: staged.objects.map((object) =>
+			object.kind === "main"
+				? {
+						byteLength: object.byteLength,
+						kind: object.kind,
+						sha256: object.sha256,
+					}
+				: {
+						agentId: object.agentId,
+						byteLength: object.byteLength,
+						kind: object.kind,
+						sha256: object.sha256,
+					},
+		),
+	};
+}
+
+function matchUploadSources(
+	stagedObjects: readonly StagedUploadObject[],
+	uploadObjects: readonly R2IngestUploadObject[],
+): readonly { readonly path: string; readonly upload: R2IngestUploadObject }[] {
+	if (stagedObjects.length !== uploadObjects.length) {
+		throw new R2IngestFlowError(
+			"R2 init response returned a different number of upload objects",
+			false,
+		);
+	}
+	const stagedByIdentity = new Map(
+		stagedObjects.map((object) => [getObjectIdentity(object), object]),
+	);
+	return uploadObjects.map((upload) => {
+		const staged = stagedByIdentity.get(getObjectIdentity(upload));
+		if (!staged) {
+			throw new R2IngestFlowError(
+				"R2 init response returned an unexpected upload object",
+				false,
+			);
+		}
+		if (
+			staged.byteLength !== upload.byteLength ||
+			staged.sha256 !== upload.sha256
+		) {
+			throw new R2IngestFlowError(
+				"R2 init response changed an upload object's size or SHA-256",
+				false,
+			);
+		}
+		return { path: staged.path, upload };
+	});
+}
+
+function getObjectIdentity(
+	object: StagedUploadObject | R2IngestUploadObject,
+): string {
+	return object.kind === "main" ? "main" : `subagent:${object.agentId}`;
+}
+
+async function callRpcWithRetry<TValue>(
+	operation: () => Promise<TValue>,
+	onRetry:
+		| ((attempt: number, maxAttempts: number, error: string) => void)
+		| undefined,
+): Promise<{ readonly attempts: number; readonly value: TValue }> {
+	for (let attempt = 1; attempt <= RPC_MAX_ATTEMPTS; attempt += 1) {
+		try {
+			return { attempts: attempt, value: await operation() };
+		} catch (error) {
+			if (!isRetryableRpcError(error) || attempt === RPC_MAX_ATTEMPTS) {
+				throw error;
+			}
+			const detail =
+				error instanceof Error ? error.message : "connection failed";
+			onRetry?.(attempt, RPC_MAX_ATTEMPTS, detail);
+			await delay(RPC_BASE_DELAY_MS * 2 ** (attempt - 1));
+		}
+	}
+	throw new Error("R2 RPC retries were exhausted");
+}
+
+function isRetryableRpcError(error: unknown): boolean {
+	if (error instanceof ORPCError) {
+		return (
+			error.status === 408 ||
+			error.status === 425 ||
+			error.status === 429 ||
+			error.status >= 500
+		);
+	}
+	return true;
+}
+
+export function formatR2UploadFlowError(error: unknown): {
+	readonly message: string;
+	readonly retryable: boolean;
+} {
+	if (error instanceof R2MultipartUploadError) {
+		return { message: error.message, retryable: error.retryable };
+	}
+	if (error instanceof R2IngestFlowError) {
+		return { message: error.message, retryable: error.retryable };
+	}
+	if (error instanceof R2IngestInitError) {
+		return { message: error.message, retryable: error.retryable };
+	}
+	if (error instanceof ORPCError) {
+		return {
+			message: `${error.status} ${error.message}`,
+			retryable: isRetryableRpcError(error),
+		};
+	}
+	const message = error instanceof Error ? error.message : "connection failed";
+	return {
+		message: `Network error during direct R2 upload: ${message}`,
+		retryable: true,
+	};
+}
+
+async function delay(milliseconds: number): Promise<void> {
+	if (milliseconds <= 0) return;
+	await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/apps/cli/src/lib/upload-reconciliation.ts
+++ b/apps/cli/src/lib/upload-reconciliation.ts
@@ -1,0 +1,282 @@
+import { ORPCError } from "@orpc/client";
+import pMap from "p-map";
+import {
+	CLI_SESSION_UPLOAD_STATUS_MAX_IDS,
+	parseSafeApiEndpoint,
+	type RepoIdentity,
+} from "../contracts/index.js";
+import type {
+	ScannedProject,
+	SessionFile,
+} from "../internal/agent-adapters/index.js";
+import { createRpcClient } from "./api-client.js";
+import { describeUploadEndpointRejection } from "./upload-endpoint.js";
+
+export interface UploadProjectTarget {
+	readonly organizationId: string | undefined;
+	readonly project: ScannedProject;
+}
+
+export interface ResolvedOrganizationUploadStatus {
+	readonly organizationId: string;
+	readonly uploadedSessionIds: ReadonlySet<string>;
+}
+
+export interface ReconciledUploadProject extends UploadProjectTarget {
+	readonly duplicateSessions: readonly SessionFile[];
+	readonly newSessions: readonly SessionFile[];
+	readonly resolvedOrganizationId: string;
+	readonly uploadedSessions: readonly SessionFile[];
+}
+
+export interface UploadReconciliationConfig {
+	readonly allowInsecureEndpoint: boolean;
+	readonly authType: "bearer" | "api-key" | undefined;
+	readonly endpoint: string;
+	readonly token: string;
+}
+
+export interface UploadProjectOrder {
+	readonly containsCwd: boolean;
+	readonly index: number;
+}
+
+export interface RepositoryUploadProject {
+	readonly newSessions: readonly SessionFile[];
+	readonly project: ScannedProject;
+	readonly repositoryIdentity: RepoIdentity;
+}
+
+export interface HookAwareRepositoryUploadProject
+	extends RepositoryUploadProject {
+	readonly hookInstalled: boolean;
+}
+
+export interface UploadRepositoryGroup<
+	TProject extends RepositoryUploadProject,
+> {
+	readonly key: string;
+	readonly label: string;
+	readonly projects: TProject[];
+}
+
+export type RepositoryHookState = "disabled" | "enabled" | "mixed";
+
+export async function reconcileUploadProjects(
+	targets: readonly UploadProjectTarget[],
+	config: UploadReconciliationConfig,
+): Promise<ReconciledUploadProject[]> {
+	const endpoint = parseSafeApiEndpoint(config.endpoint, {
+		allowPlaintext: config.allowInsecureEndpoint,
+	});
+	if (!endpoint.ok) {
+		throw new Error(
+			`Upload endpoint refused: ${describeUploadEndpointRejection(endpoint)}`,
+		);
+	}
+
+	const client = createRpcClient({
+		rpcUrl: endpoint.url,
+		token: config.token,
+		authType: config.authType,
+	});
+	const sessionIdsByOrganization = collectSessionIdsByOrganization(targets);
+	const statusEntries = await pMap(
+		Array.from(sessionIdsByOrganization),
+		async ([organizationId, sessionIds]) => {
+			const responses = await pMap(
+				chunk(sessionIds, CLI_SESSION_UPLOAD_STATUS_MAX_IDS),
+				(ids) =>
+					client.cli.sessionUploadStatus({
+						organizationId,
+						sessionIds: ids,
+					}),
+				{ concurrency: 4 },
+			);
+			const firstResponse = responses[0];
+			if (!firstResponse) {
+				throw new Error("Upload status response was empty");
+			}
+			const uploadedSessionIds = new Set<string>();
+			for (const response of responses) {
+				if (response.organizationId !== firstResponse.organizationId) {
+					throw new Error("Upload status resolved inconsistent organizations");
+				}
+				for (const sessionId of response.uploadedSessionIds) {
+					uploadedSessionIds.add(sessionId);
+				}
+			}
+			return [
+				organizationId,
+				{
+					organizationId: firstResponse.organizationId,
+					uploadedSessionIds,
+				},
+			] as const;
+		},
+		{ concurrency: 4 },
+	).catch((error: unknown) => {
+		throw new Error(formatUploadReconciliationError(error));
+	});
+
+	return classifyUploadProjects(targets, new Map(statusEntries));
+}
+
+export function classifyUploadProjects(
+	targets: readonly UploadProjectTarget[],
+	statusByRequestedOrganization: ReadonlyMap<
+		string | undefined,
+		ResolvedOrganizationUploadStatus
+	>,
+): ReconciledUploadProject[] {
+	const locallyClaimedByOrganization = new Map<string, Set<string>>();
+
+	return targets.map((target) => {
+		const status = statusByRequestedOrganization.get(target.organizationId);
+		if (!status) {
+			throw new Error("Upload status is missing for a target organization");
+		}
+		const locallyClaimed =
+			locallyClaimedByOrganization.get(status.organizationId) ?? new Set();
+		locallyClaimedByOrganization.set(status.organizationId, locallyClaimed);
+
+		const newSessions: SessionFile[] = [];
+		const uploadedSessions: SessionFile[] = [];
+		const duplicateSessions: SessionFile[] = [];
+		for (const session of target.project.sessions) {
+			if (status.uploadedSessionIds.has(session.sessionId)) {
+				uploadedSessions.push(session);
+				continue;
+			}
+			if (locallyClaimed.has(session.sessionId)) {
+				duplicateSessions.push(session);
+				continue;
+			}
+			locallyClaimed.add(session.sessionId);
+			newSessions.push(session);
+		}
+
+		return {
+			...target,
+			duplicateSessions,
+			newSessions,
+			resolvedOrganizationId: status.organizationId,
+			uploadedSessions,
+		};
+	});
+}
+
+export function groupUploadProjectsByRepository<
+	TProject extends RepositoryUploadProject,
+>(projects: readonly TProject[]): UploadRepositoryGroup<TProject>[] {
+	const groups = new Map<string, UploadRepositoryGroup<TProject>>();
+
+	for (const project of projects) {
+		const existing = groups.get(project.repositoryIdentity.repoKey);
+		if (existing) {
+			existing.projects.push(project);
+			continue;
+		}
+		groups.set(project.repositoryIdentity.repoKey, {
+			key: project.repositoryIdentity.repoKey,
+			label: project.repositoryIdentity.repoLabel,
+			projects: [project],
+		});
+	}
+
+	return Array.from(groups.values());
+}
+
+export function getRepositoryHookState<
+	TProject extends HookAwareRepositoryUploadProject,
+>(repository: UploadRepositoryGroup<TProject>): RepositoryHookState {
+	const enabledCount = repository.projects.filter(
+		(project) => project.hookInstalled,
+	).length;
+	if (enabledCount === 0) return "disabled";
+	if (enabledCount === repository.projects.length) return "enabled";
+	return "mixed";
+}
+
+export function orderUploadRepositoriesNewFirst<
+	TProject extends RepositoryUploadProject,
+>(
+	repositories: readonly UploadRepositoryGroup<TProject>[],
+	projectOrder: ReadonlyMap<ScannedProject, UploadProjectOrder>,
+): UploadRepositoryGroup<TProject>[] {
+	return [...repositories].sort((left, right) => {
+		const leftHasNew = repositoryHasNewSessions(left);
+		const rightHasNew = repositoryHasNewSessions(right);
+		if (leftHasNew !== rightHasNew) return leftHasNew ? -1 : 1;
+		const leftOrder = getRepositoryOrder(left, projectOrder);
+		const rightOrder = getRepositoryOrder(right, projectOrder);
+		if (leftOrder?.containsCwd !== rightOrder?.containsCwd) {
+			return leftOrder?.containsCwd ? -1 : 1;
+		}
+		return (leftOrder?.index ?? 0) - (rightOrder?.index ?? 0);
+	});
+}
+
+function repositoryHasNewSessions<TProject extends RepositoryUploadProject>(
+	repository: UploadRepositoryGroup<TProject>,
+): boolean {
+	return repository.projects.some((project) => project.newSessions.length > 0);
+}
+
+function getRepositoryOrder<TProject extends RepositoryUploadProject>(
+	repository: UploadRepositoryGroup<TProject>,
+	projectOrder: ReadonlyMap<ScannedProject, UploadProjectOrder>,
+): UploadProjectOrder | undefined {
+	let containsCwd = false;
+	let index: number | undefined;
+	for (const project of repository.projects) {
+		const order = projectOrder.get(project.project);
+		if (!order) continue;
+		containsCwd ||= order.containsCwd;
+		index = index === undefined ? order.index : Math.min(index, order.index);
+	}
+	return index === undefined ? undefined : { containsCwd, index };
+}
+
+function collectSessionIdsByOrganization(
+	targets: readonly UploadProjectTarget[],
+): Map<string | undefined, string[]> {
+	const sessionIdsByOrganization = new Map<string | undefined, Set<string>>();
+	for (const target of targets) {
+		const sessionIds =
+			sessionIdsByOrganization.get(target.organizationId) ?? new Set<string>();
+		sessionIdsByOrganization.set(target.organizationId, sessionIds);
+		for (const session of target.project.sessions) {
+			sessionIds.add(session.sessionId);
+		}
+	}
+
+	return new Map(
+		Array.from(sessionIdsByOrganization, ([organizationId, sessionIds]) => [
+			organizationId,
+			Array.from(sessionIds),
+		]),
+	);
+}
+
+function chunk<TValue>(values: readonly TValue[], maxSize: number): TValue[][] {
+	const chunks: TValue[][] = [];
+	for (let index = 0; index < values.length; index += maxSize) {
+		chunks.push(values.slice(index, index + maxSize));
+	}
+	return chunks;
+}
+
+function formatUploadReconciliationError(error: unknown): string {
+	if (
+		error instanceof ORPCError &&
+		(error.status === 401 || error.status === 403)
+	) {
+		return "Could not check uploaded sessions because authentication expired. Run `rudel login` and try again.";
+	}
+	if (error instanceof ORPCError) {
+		return `Could not check uploaded sessions (${error.status} ${error.message}). No sessions were uploaded.`;
+	}
+	const message = error instanceof Error ? error.message : "connection failed";
+	return `Could not check uploaded sessions: ${message}. No sessions were uploaded.`;
+}

--- a/apps/cli/src/lib/upload-reconciliation.ts
+++ b/apps/cli/src/lib/upload-reconciliation.ts
@@ -272,7 +272,7 @@ function formatUploadReconciliationError(error: unknown): string {
 		error instanceof ORPCError &&
 		(error.status === 401 || error.status === 403)
 	) {
-		return "Could not check uploaded sessions because authentication expired. Run `rudel login` and try again.";
+		return "Could not check uploaded sessions because authentication expired. Run `opaline login` and try again.";
 	}
 	if (error instanceof ORPCError) {
 		return `Could not check uploaded sessions (${error.status} ${error.message}). No sessions were uploaded.`;

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -1,3 +1,4 @@
+import { readFile, stat } from "node:fs/promises";
 import { createORPCClient, ORPCError } from "@orpc/client";
 import { RPCLink } from "@orpc/client/fetch";
 import type { ContractRouterClient } from "@orpc/contract";
@@ -13,7 +14,10 @@ import {
 	SESSION_OWNERSHIP_CONFLICT_CODE,
 	SESSION_UPLOAD_SHRINK_REJECTED_CODE,
 } from "../contracts/index.js";
-import { isMissingTranscriptTimestampMessage } from "../internal/agent-adapters/index.js";
+import {
+	type FileBackedUploadRequest,
+	isMissingTranscriptTimestampMessage,
+} from "../internal/agent-adapters/index.js";
 import {
 	FILTER_VERSION,
 	filterSessionTextFields,
@@ -26,6 +30,18 @@ import {
 	SecretFilterJsonIntegrityError,
 	type SessionTextFilterResult,
 } from "../internal/secret-filter/index.js";
+import { hasR2IngestUpgradeHint } from "./r2-ingest-contract.js";
+import type { R2MultipartProgress } from "./r2-multipart-upload.js";
+import {
+	forgetR2UploadCapability,
+	hasAdvertisedR2UploadCapability,
+	rememberR2UploadCapability,
+} from "./r2-upload-capability.js";
+import {
+	formatR2UploadFlowError,
+	isR2InitUnsupported,
+	uploadSessionViaR2,
+} from "./r2-upload-flow.js";
 import type { UploadResult } from "./types.js";
 import { describeUploadEndpointRejection } from "./upload-endpoint.js";
 
@@ -36,11 +52,15 @@ export interface UploadConfig {
 	authType?: "bearer" | "api-key";
 	maxAggregateBytes?: number;
 	onRetry?: (attempt: number, maxAttempts: number, error: string) => void;
+	onProgress?: (progress: R2MultipartProgress) => void;
+	r2MultipartBaseDelayMs?: number;
+	r2StatusPollIntervalMs?: number;
 }
 
 const RETRYABLE_STATUS_CODES = new Set([408, 502, 503, 504]);
 const MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 1_000;
+const LEGACY_MATERIALIZATION_MAX_BYTES = 32 * 1024 * 1024;
 
 interface ErrorData {
 	readonly authMessage: string | null;
@@ -54,6 +74,31 @@ interface ErrorData {
 }
 
 type UploadSubagent = NonNullable<IngestSessionInput["subagents"]>[number];
+type UploadSessionRequest = FileBackedUploadRequest | IngestSessionInput;
+
+type LegacyUploadPreparation =
+	| {
+			readonly status: "empty-main";
+	  }
+	| {
+			readonly anomaly: RedactionBudgetAnomaly;
+			readonly status: "redaction-budget";
+	  }
+	| {
+			readonly actualBytes: number;
+			readonly maxBytes: number;
+			readonly status: "legacy-too-large";
+	  }
+	| {
+			readonly actualBytes: number;
+			readonly maxBytes: number;
+			readonly status: "too-large";
+	  }
+	| {
+			readonly filteredRequest: IngestSessionInput;
+			readonly filteredText: SessionTextFilterResult<UploadSubagent>;
+			readonly status: "ready";
+	  };
 
 export function isRetryableUploadError(error: unknown): boolean {
 	if (error instanceof ORPCError) {
@@ -294,55 +339,11 @@ function formatWait(milliseconds: number) {
  * Rate limit errors (429) are not retried — the window is too long.
  */
 export async function uploadSession(
-	request: IngestSessionInput,
+	request: UploadSessionRequest,
 	config: UploadConfig,
 ): Promise<UploadResult> {
-	const inputBytes = getUploadAggregateBytes(request);
-	let filteredText: SessionTextFilterResult<UploadSubagent>;
-	try {
-		filteredText = filterSessionTextFields({
-			content: request.content,
-			subagents: request.subagents,
-		});
-	} catch (error) {
-		const filterFailure = getSecretFilterUploadFailure(error);
-		if (filterFailure) {
-			return filterFailure;
-		}
-		throw error;
-	}
-	const redactionBudgetAnomaly = getRedactionBudgetAnomaly(
-		filteredText.redactedBytes,
-		inputBytes,
-		filteredText.counts,
-	);
-	if (redactionBudgetAnomaly) {
-		return {
-			success: false,
-			error: formatRedactionBudgetError(redactionBudgetAnomaly),
-			attempts: 0,
-			redactionBudgetExceeded: true,
-			retryable: false,
-		};
-	}
-	const filteredRequest: IngestSessionInput = {
-		...request,
-		content: filteredText.content,
-		subagents: filteredText.subagents ? [...filteredText.subagents] : undefined,
-		filter_version: FILTER_VERSION,
-	};
 	const maxAggregateBytes =
 		config.maxAggregateBytes ?? INGEST_AGGREGATE_CONTENT_MAX_BYTES;
-	const aggregateBytes = getUploadAggregateBytes(filteredRequest);
-	if (aggregateBytes > maxAggregateBytes) {
-		return {
-			success: false,
-			error: formatTranscriptTooLargeError(aggregateBytes, maxAggregateBytes),
-			attempts: 0,
-			retryable: false,
-		};
-	}
-
 	const endpoint = parseSafeApiEndpoint(config.endpoint, {
 		allowPlaintext: config.allowInsecureEndpoint,
 	});
@@ -365,6 +366,111 @@ export async function uploadSession(
 	});
 
 	const client: ContractRouterClient<typeof contract> = createORPCClient(link);
+	const authType = config.authType ?? "bearer";
+	const endpointUrl = new URL(endpoint.url);
+	if (
+		authType === "api-key" &&
+		hasAdvertisedR2UploadCapability(endpointUrl, authType, config.token)
+	) {
+		try {
+			const r2Result = await uploadSessionViaR2(request, {
+				authType,
+				endpoint: endpointUrl,
+				maxAggregateBytes,
+				multipartBaseDelayMs: config.r2MultipartBaseDelayMs,
+				onProgress: config.onProgress,
+				onRetry: config.onRetry,
+				statusPollIntervalMs: config.r2StatusPollIntervalMs,
+				token: config.token,
+			});
+			if (r2Result.status === "redaction-budget") {
+				return {
+					success: false,
+					error: formatRedactionBudgetError(r2Result.anomaly),
+					attempts: 0,
+					redactionBudgetExceeded: true,
+					retryable: false,
+				};
+			}
+			if (r2Result.status === "empty-main") {
+				return getEmptyMainUploadFailure();
+			}
+			if (r2Result.status === "too-large") {
+				return {
+					success: false,
+					error: formatTranscriptTooLargeError(
+						r2Result.actualBytes,
+						r2Result.maxBytes,
+					),
+					attempts: 0,
+					retryable: false,
+				};
+			}
+			return {
+				success: true,
+				status: 200,
+				attempts: r2Result.attempts,
+				redacted: r2Result.redactions,
+				redactedBytes: r2Result.redactedBytes,
+				usageChecksum: r2Result.result.usageChecksum,
+			};
+		} catch (error) {
+			const filterFailure = getSecretFilterUploadFailure(error);
+			if (filterFailure) return filterFailure;
+			if (isR2InitUnsupported(error)) {
+				await forgetR2UploadCapability(endpointUrl, authType, config.token);
+			} else {
+				const failure = formatR2UploadFlowError(error);
+				return {
+					success: false,
+					error: failure.message,
+					attempts: MAX_ATTEMPTS,
+					retryable: failure.retryable,
+				};
+			}
+		}
+	}
+
+	let legacy: LegacyUploadPreparation;
+	try {
+		legacy = await prepareLegacyUpload(request, maxAggregateBytes);
+	} catch (error) {
+		const filterFailure = getSecretFilterUploadFailure(error);
+		if (filterFailure) return filterFailure;
+		throw error;
+	}
+	if (legacy.status === "redaction-budget") {
+		return {
+			success: false,
+			error: formatRedactionBudgetError(legacy.anomaly),
+			attempts: 0,
+			redactionBudgetExceeded: true,
+			retryable: false,
+		};
+	}
+	if (legacy.status === "empty-main") {
+		return getEmptyMainUploadFailure();
+	}
+	if (legacy.status === "legacy-too-large") {
+		return {
+			success: false,
+			error: formatLegacyServerTooLargeError(
+				legacy.actualBytes,
+				legacy.maxBytes,
+			),
+			attempts: 0,
+			retryable: false,
+		};
+	}
+	if (legacy.status === "too-large") {
+		return {
+			success: false,
+			error: formatTranscriptTooLargeError(legacy.actualBytes, legacy.maxBytes),
+			attempts: 0,
+			retryable: false,
+		};
+	}
+	const { filteredRequest, filteredText } = legacy;
 
 	for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
 		try {
@@ -379,6 +485,9 @@ export async function uploadSession(
 					attempts: attempt,
 					retryable: false,
 				};
+			}
+			if (authType === "api-key" && hasR2IngestUpgradeHint(response)) {
+				await rememberR2UploadCapability(endpointUrl, authType, config.token);
 			}
 			return {
 				success: true,
@@ -396,7 +505,10 @@ export async function uploadSession(
 			if (
 				error instanceof ORPCError &&
 				error.status === 400 &&
-				isMissingTranscriptTimestampMessage(request.source, error.message)
+				isMissingTranscriptTimestampMessage(
+					filteredRequest.source,
+					error.message,
+				)
 			) {
 				return {
 					success: false,
@@ -466,6 +578,102 @@ export async function uploadSession(
 	};
 }
 
+async function prepareLegacyUpload(
+	request: UploadSessionRequest,
+	maxAggregateBytes: number,
+): Promise<LegacyUploadPreparation> {
+	if (isFileBackedUploadRequest(request)) {
+		const sourceBytes = await getFileBackedAggregateBytes(request);
+		if (sourceBytes > LEGACY_MATERIALIZATION_MAX_BYTES) {
+			return {
+				actualBytes: sourceBytes,
+				maxBytes: LEGACY_MATERIALIZATION_MAX_BYTES,
+				status: "legacy-too-large",
+			};
+		}
+	}
+	const materialized = await materializeLegacyUploadRequest(request);
+	const inputBytes = getUploadAggregateBytes(materialized);
+	const filteredText = filterSessionTextFields({
+		content: materialized.content,
+		subagents: materialized.subagents,
+	});
+	if (Buffer.byteLength(filteredText.content, "utf8") === 0) {
+		return { status: "empty-main" };
+	}
+	const anomaly = getRedactionBudgetAnomaly(
+		filteredText.redactedBytes,
+		inputBytes,
+		filteredText.counts,
+	);
+	if (anomaly) return { anomaly, status: "redaction-budget" };
+	const nonEmptySubagents = filteredText.subagents?.filter(
+		(subagent) => Buffer.byteLength(subagent.content, "utf8") > 0,
+	);
+	const filteredRequest: IngestSessionInput = {
+		...materialized,
+		content: filteredText.content,
+		subagents:
+			nonEmptySubagents && nonEmptySubagents.length > 0
+				? [...nonEmptySubagents]
+				: undefined,
+		filter_version: FILTER_VERSION,
+	};
+	const aggregateBytes = getUploadAggregateBytes(filteredRequest);
+	if (aggregateBytes > maxAggregateBytes) {
+		return {
+			actualBytes: aggregateBytes,
+			maxBytes: maxAggregateBytes,
+			status: "too-large",
+		};
+	}
+	return { filteredRequest, filteredText, status: "ready" };
+}
+
+async function getFileBackedAggregateBytes(
+	request: FileBackedUploadRequest,
+): Promise<number> {
+	const files = await Promise.all([
+		stat(request.transcriptPath),
+		...request.subagents.map((subagent) => stat(subagent.path)),
+	]);
+	return files.reduce((total, file) => total + file.size, 0);
+}
+
+async function materializeLegacyUploadRequest(
+	request: UploadSessionRequest,
+): Promise<IngestSessionInput> {
+	if (!isFileBackedUploadRequest(request)) return request;
+	const content = await readFile(request.transcriptPath, "utf8");
+	const subagents: UploadSubagent[] = [];
+	for (const subagent of request.subagents) {
+		subagents.push({
+			agentId: subagent.agentId,
+			content: await readFile(subagent.path, "utf8"),
+		});
+	}
+	return {
+		...request.metadata,
+		content,
+		subagents: subagents.length > 0 ? subagents : undefined,
+	};
+}
+
+function isFileBackedUploadRequest(
+	request: UploadSessionRequest,
+): request is FileBackedUploadRequest {
+	return "kind" in request && request.kind === "file";
+}
+
+function getEmptyMainUploadFailure(): UploadResult {
+	return {
+		success: false,
+		error: "The main session transcript is empty. Nothing was uploaded.",
+		attempts: 0,
+		retryable: false,
+	};
+}
+
 export function formatRedactionSummary(
 	counts: RedactionCounts | undefined,
 	redactedBytes: number | undefined,
@@ -502,6 +710,7 @@ export function formatRedactionBudgetError(
 interface IngestSessionResponse {
 	readonly success: true;
 	readonly sessionId: string;
+	readonly upgradeHint?: { readonly protocol: "r2_multipart_v1" };
 	readonly redacted?: RedactionCounts;
 	readonly redactedBytes?: number;
 	readonly usageChecksum?: string;
@@ -559,6 +768,13 @@ function formatTranscriptTooLargeError(
 	const actualText = `${formatMebibytes(actualBytes)} MiB`;
 	const limitText = `the ${formatMebibytes(maxBytes)} MiB per-session limit`;
 	return `Session transcript payload is ${actualText}, above ${limitText}. Reduce the transcript/subagent payload before retrying.`;
+}
+
+function formatLegacyServerTooLargeError(
+	actualBytes: number,
+	maxBytes: number,
+): string {
+	return `Transcript too large for this server: the ${formatMebibytes(actualBytes)} MiB transcript/subagent payload exceeds the CLI's ${formatMebibytes(maxBytes)} MiB safe limit for legacy uploads. Upgrade the Opaline server to one that supports direct R2 uploads, or upload a smaller transcript.`;
 }
 
 function formatMebibytes(bytes: number): string {

--- a/apps/cli/src/run-cli.ts
+++ b/apps/cli/src/run-cli.ts
@@ -10,12 +10,14 @@ import {
 	getBaseCliEventPayload,
 	shutdownCliProductAnalytics,
 } from "./lib/product-analytics.js";
+import { initializeR2StagingCleanup } from "./lib/r2-staging-cleanup.js";
 
 export async function runCli(
 	args: readonly string[] = process.argv.slice(2),
 ): Promise<void> {
 	const commandName = getTopLevelCommandName(args);
 	debugLog("starting command", { command: commandName, version: pkg.version });
+	await initializeR2StagingCleanup();
 	if (commandName !== "doctor") {
 		trackFirstRun(commandName);
 	}


### PR DESCRIPTION
Ports the reviewed R2 direct-upload work from the pre-split monorepo (`berlin-v2` branch `feat/r2-upload`, source commits through `701c2a1d`) into the canonical CLI repo.

## What's in
- Capability-gated R2 multipart uploads (`r2_multipart_v1` advertised by legacy ingest response; unsupported init clears capability and falls back to legacy ingest)
- Client-side secret filtering with bounded filtered staging (no full-transcript materialization; 100+ MiB transcripts stream)
- Staging cleanup + repository-scoped upload reconciliation
- Full feature test suite ported to in-process fetch transports

## Port adaptations (full log in reviewer notes)
- `@rudel/api-routes` / `@rudel/agent-adapters` / `@rudel/secret-filter` imports mapped to the repo's vendored modules under `apps/cli/src/contracts` and `apps/cli/src/internal`
- Kept `@opalinehq/cli` naming, `OPALINE_*` env vars, and the target's newer README/CHANGELOG structure
- Excluded stale monorepo hunks (old private-API integration suites, old workspace scripts) — each exclusion reasoned individually

## Verification
- `bun run verify` green from root: **667 pass, 0 fail** (9,293 assertions, 33 files)
- Focused feature gate: 54 pass, 185 assertions

Review focus: the adaptation layer (import mapping + merged `createRpcClient`), not the feature logic — the feature itself was 4-pass reviewed in the source tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790313039&installation_model_id=433970&pr_number=466&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F466&signature=ec55b21e6573b08ee713f1020f2b5e358401ae1b9271f45cc0940e2527d16c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->