### PR TITLE
chore: release opaline cli 0.5.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"apps/cli": "0.4.0",
-	"packages/rudel-alias": "0.4.0"
+	"apps/cli": "0.5.0",
+	"packages/rudel-alias": "0.5.0"
 }

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.0
+
+### Features
+
+- Add bounded R2 multipart uploads with resumable progress and legacy-ingest fallback.
+- Filter known secrets locally before either upload transport and report merged redaction counts.
+- Preserve unrelated coding-agent hooks and reconcile automatic-upload configuration safely.
+
+### Bug fixes
+
+- Keep existing credentials compatible with the legacy API hostname.
+- Ship executable bin paths accepted by current npm publish validation.
+
 ## 0.4.0
 
 ### Breaking changes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@opalinehq/cli",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"type": "module",
 	"description": "Opaline CLI for Claude Code and Codex session analytics",
 	"license": "MIT",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/cli": {
       "name": "@opalinehq/cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "bin": {
         "opaline": "./dist/cli.js",
       },
@@ -36,12 +36,12 @@
     },
     "packages/rudel-alias": {
       "name": "rudel",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "bin": {
         "rudel": "./bin/rudel.js",
       },
       "dependencies": {
-        "@opalinehq/cli": "0.4.0",
+        "@opalinehq/cli": "0.5.0",
       },
     },
   },

--- a/packages/rudel-alias/CHANGELOG.md
+++ b/packages/rudel-alias/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0
+
+- Point the `rudel` compatibility executable at `@opalinehq/cli@0.5.0`.
+
 ## 0.4.0
 
 - Delegate the `rudel` executable to `@opalinehq/cli` with a stderr-only rename notice.

--- a/packages/rudel-alias/package.json
+++ b/packages/rudel-alias/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rudel",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"type": "module",
 	"description": "Compatibility alias for the Opaline CLI",
 	"license": "MIT",
@@ -31,6 +31,6 @@
 		"README.md"
 	],
 	"dependencies": {
-		"@opalinehq/cli": "0.4.0"
+		"@opalinehq/cli": "0.5.0"
 	}
 }


### PR DESCRIPTION
## Summary
- release `@opalinehq/cli` and the `rudel` compatibility alias in lockstep at 0.5.0
- document R2 multipart upload, client-side secret filtering, hook preservation, and compatibility fixes
- update the workspace lockfile and release manifest

## Test plan
- `bun run verify`
- built CLI reports `0.5.0`
- merged CLI production legacy-upload smoke succeeded with one expected GitHub PAT redaction

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790492095&installation_model_id=433970&pr_number=467&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F467&signature=4d1ea70537ab5c3edff1485d6d59715260c2bb36afa3de2c7ab5920d79873f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->