### PR TITLE
fix: wait for terminal R2 ingest status

### DIFF
--- a/apps/cli/src/__tests__/r2-upload-flow.test.ts
+++ b/apps/cli/src/__tests__/r2-upload-flow.test.ts
@@ -218,6 +218,130 @@ describe("capability-gated R2 upload flow", () => {
 		});
 	});
 
+	test("polls terminal status when commit retries end with a busy job", async () => {
+		await isolateCapabilityCache();
+		const requestPaths: string[] = [];
+		let commitCalls = 0;
+		let statusCalls = 0;
+		let server: FetchStub;
+		server = serveFetchStub({
+			hostname: "127.0.0.1",
+			port: 0,
+			async fetch(request) {
+				const pathname = new URL(request.url).pathname;
+				requestPaths.push(pathname);
+				if (pathname === "/r2/busy/part/1") {
+					await request.arrayBuffer();
+					return new Response(null, { headers: { etag: '"busy-etag"' } });
+				}
+
+				const input = await readRpcInput(request);
+				if (pathname === "/rpc/ingest/init") {
+					const main = getMainObject(input);
+					const byteLength = getRequiredNumber(main, "byteLength");
+					return rpcResponse({
+						expiresAt: "2026-08-25T12:15:00.000Z",
+						jobId: JOB_ID,
+						objects: [
+							{
+								byteLength,
+								kind: "main",
+								objectKey: `ingest/${JOB_ID}/main.jsonl`,
+								parts: [
+									{
+										byteLength,
+										headers: {
+											"Content-Length": byteLength.toString(),
+										},
+										partNumber: 1,
+										uploadUrl: `http://127.0.0.1:${server.port}/r2/busy/part/1`,
+									},
+								],
+								sha256: getRequiredString(main, "sha256"),
+								uploadId: "busy-upload",
+							},
+						],
+						partSizeBytes: R2_INGEST_PART_SIZE_BYTES,
+						protocol: "r2_multipart_v1",
+					});
+				}
+				if (pathname === "/rpc/ingest/commit") {
+					const failures = [
+						{
+							message: "Language-signal scanning temporarily failed",
+							reason: "language_signal_scanner_failed",
+						},
+						{
+							message: "Ingest job is waiting for its retry window",
+							reason: "R2_INGEST_JOB_RETRY_LATER",
+						},
+						{
+							message: "Ingest job is already being processed",
+							reason: "R2_INGEST_JOB_BUSY",
+						},
+					];
+					const failure = failures[commitCalls];
+					commitCalls += 1;
+					if (!failure) throw new Error("unexpected commit retry");
+					return Response.json(
+						{
+							json: {
+								code: "SERVICE_UNAVAILABLE",
+								data: { reason: failure.reason, retryAfterMs: 1_000 },
+								defined: false,
+								message: failure.message,
+								status: 503,
+							},
+						},
+						{ status: 503 },
+					);
+				}
+				if (pathname === "/rpc/ingest/status") {
+					statusCalls += 1;
+					return rpcResponse({
+						attempts: 2,
+						availableAt: "2026-08-25T12:00:00.000Z",
+						error: null,
+						jobId: JOB_ID,
+						leaseExpiresAt:
+							statusCalls === 1 ? "2026-08-25T12:30:00.000Z" : null,
+						protocol: "r2_multipart_v1",
+						result:
+							statusCalls === 1
+								? null
+								: createSuccessResult("busy-recovery-session"),
+						status: statusCalls === 1 ? "running" : "completed",
+						updatedAt: "2026-08-25T12:00:01.000Z",
+					});
+				}
+				return new Response("not found", { status: 404 });
+			},
+		});
+		activeServers.push(server);
+		const config = createUploadConfig(server);
+		await rememberR2UploadCapability(
+			new URL(config.endpoint),
+			"api-key",
+			TOKEN,
+		);
+
+		const result = await uploadSession(
+			createRequest("busy-recovery-session", "clean"),
+			config,
+		);
+
+		expect(result).toMatchObject({ attempts: 3, success: true });
+		expect(requestPaths).toEqual([
+			"/rpc/ingest/init",
+			"/r2/busy/part/1",
+			"/rpc/ingest/commit",
+			"/rpc/ingest/commit",
+			"/rpc/ingest/commit",
+			"/rpc/ingest/status",
+			"/rpc/ingest/status",
+		]);
+	});
+
 	test("rejects an over-budget streamed transcript before R2 init or PUT while a normal transcript passes", async () => {
 		await isolateCapabilityCache();
 		const directory = await mkdtemp(join(tmpdir(), "opaline-r2-budget-"));

--- a/apps/cli/src/lib/r2-upload-flow.ts
+++ b/apps/cli/src/lib/r2-upload-flow.ts
@@ -32,8 +32,15 @@ import {
 
 const RPC_MAX_ATTEMPTS = 3;
 const RPC_BASE_DELAY_MS = 500;
-const STATUS_MAX_POLLS = 20;
-const STATUS_POLL_INTERVAL_MS = 500;
+// Commit normally returns the terminal result. This longer fallback is used
+// only when another worker owns the accepted job, and stays bounded so an
+// automatic-upload hook cannot remain alive indefinitely.
+const STATUS_MAX_POLLS = 300;
+const STATUS_POLL_INTERVAL_MS = 1_000;
+const COMMITTED_JOB_IN_PROGRESS_REASONS = new Set([
+	"R2_INGEST_JOB_BUSY",
+	"R2_INGEST_JOB_RETRY_LATER",
+]);
 
 export interface R2UploadFlowConfig {
 	readonly authType: "api-key" | "bearer";
@@ -178,29 +185,43 @@ async function uploadStagedSession(
 		jobId: initCall.value.jobId,
 		objects: multipart.objects,
 	};
-	const commitCall = await callRpcWithRetry(
-		() => client.ingest.commit(commitInput),
-		config.onRetry,
-	);
-	if (!isR2IngestCommitOutput(commitCall.value)) {
-		throw new R2IngestFlowError(
-			"Opaline API returned an invalid R2 commit response",
-			false,
+	let commitAttempts = RPC_MAX_ATTEMPTS;
+	let commitResult: R2IngestSuccess | null = null;
+	try {
+		const commitCall = await callRpcWithRetry(
+			() => client.ingest.commit(commitInput),
+			config.onRetry,
 		);
-	}
-	if (commitCall.value.jobId !== initCall.value.jobId) {
-		throw new R2IngestFlowError(
-			"Opaline API returned an R2 commit response for a different job",
-			false,
-		);
+		commitAttempts = commitCall.attempts;
+		if (!isR2IngestCommitOutput(commitCall.value)) {
+			throw new R2IngestFlowError(
+				"Opaline API returned an invalid R2 commit response",
+				false,
+			);
+		}
+		if (commitCall.value.jobId !== initCall.value.jobId) {
+			throw new R2IngestFlowError(
+				"Opaline API returned an R2 commit response for a different job",
+				false,
+			);
+		}
+		commitResult = commitCall.value.result;
+	} catch (error) {
+		if (!isCommittedJobInProgressError(error)) throw error;
 	}
 	const statusCall = await pollJobStatus(client, initCall.value.jobId, config);
-	const serverResult = statusCall.result ?? commitCall.value.result;
+	const serverResult = statusCall.result ?? commitResult;
+	if (!serverResult) {
+		throw new R2IngestFlowError(
+			"Opaline API returned a completed R2 status without a result",
+			false,
+		);
+	}
 	return {
 		attempts: Math.max(
 			initCall.attempts,
 			multipart.attempts,
-			commitCall.attempts,
+			commitAttempts,
 			statusCall.attempts,
 		),
 		redactedBytes: staged.redactedBytes + (serverResult.redactedBytes ?? 0),
@@ -353,6 +374,14 @@ function isRetryableRpcError(error: unknown): boolean {
 	return true;
 }
 
+function isCommittedJobInProgressError(error: unknown): boolean {
+	if (!(error instanceof ORPCError) || !isRecord(error.data)) return false;
+	const reason = error.data.reason;
+	return (
+		typeof reason === "string" && COMMITTED_JOB_IN_PROGRESS_REASONS.has(reason)
+	);
+}
+
 export function formatR2UploadFlowError(error: unknown): {
 	readonly message: string;
 	readonly retryable: boolean;
@@ -382,4 +411,8 @@ export function formatR2UploadFlowError(error: unknown): {
 async function delay(milliseconds: number): Promise<void> {
 	if (milliseconds <= 0) return;
 	await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
 }


### PR DESCRIPTION
## Summary

- keep polling accepted R2 ingest jobs when the final commit retry reports busy or retry-later
- use a bounded five-minute terminal-status window so slow background completion is not reported as failure
- cover the exact production sequence: processing failure, retry-later, busy, running, completed

## Production evidence

A large-session smoke completed server-side on its second attempt with all four receipts, including 3,860 usage events. The released CLI returned a false busy failure roughly ten seconds before that background job completed.

## Test plan

- [x] `bun run verify` — 672 tests passed, typecheck, Biome, and build green
- [x] focused R2 upload-flow tests — 10 passed, including the new regression and 100+ MiB memory cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790508254&installation_model_id=433970&pr_number=468&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F468&signature=056f14a7d9d570db3910bcd8b8374d0e842e281c5679aa2c1a779526fa4fdda7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->