### PR TITLE
chore: release opaline cli 0.5.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-	"apps/cli": "0.5.0",
-	"packages/rudel-alias": "0.5.0"
+	"apps/cli": "0.5.1",
+	"packages/rudel-alias": "0.5.1"
 }

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.1
+
+### Bug fixes
+
+- Keep polling accepted R2 ingest jobs after busy or retry-later commit responses so successful background completion is not reported as failure.
+
 ## 0.5.0
 
 ### Features

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@opalinehq/cli",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"type": "module",
 	"description": "Opaline CLI for Claude Code and Codex session analytics",
 	"license": "MIT",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/cli": {
       "name": "@opalinehq/cli",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "bin": {
         "opaline": "./dist/cli.js",
       },
@@ -36,12 +36,12 @@
     },
     "packages/rudel-alias": {
       "name": "rudel",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "bin": {
         "rudel": "./bin/rudel.js",
       },
       "dependencies": {
-        "@opalinehq/cli": "0.5.0",
+        "@opalinehq/cli": "0.5.1",
       },
     },
   },

--- a/packages/rudel-alias/CHANGELOG.md
+++ b/packages/rudel-alias/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- Point the `rudel` compatibility executable at `@opalinehq/cli@0.5.1`.
+
 ## 0.5.0
 
 - Point the `rudel` compatibility executable at `@opalinehq/cli@0.5.0`.

--- a/packages/rudel-alias/package.json
+++ b/packages/rudel-alias/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rudel",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"type": "module",
 	"description": "Compatibility alias for the Opaline CLI",
 	"license": "MIT",
@@ -31,6 +31,6 @@
 		"README.md"
 	],
 	"dependencies": {
-		"@opalinehq/cli": "0.5.0"
+		"@opalinehq/cli": "0.5.1"
 	}
 }


### PR DESCRIPTION
## Summary

- release the terminal R2 ingest-status polling fix as `@opalinehq/cli@0.5.1`
- keep the legacy `rudel` alias in lockstep at `0.5.1`
- update both changelogs, package metadata, manifest, and lockfile

Release Please computed `0.5.1` but could not create its branch because `RELEASE_PLEASE_TOKEN` received a GitHub 403. This PR mirrors the established manual `0.5.0` fallback.

## Test plan

- [x] `bun run verify` — 672 tests passed, typecheck, Biome, and build green
- [x] `git diff --check`
- [x] verified both packages and the alias dependency remain version-locked

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790509213&installation_model_id=433970&pr_number=469&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F469&signature=8d407117cce114271e68db3019be57d166fd3393bb28060079e0f2d86b1b37b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->