### PR TITLE
fix: release only canonical Opaline package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,6 @@ jobs:
       cli_release_created: ${{ steps.release.outputs['apps/cli--release_created'] }}
       cli_tag_name: ${{ steps.release.outputs['apps/cli--tag_name'] }}
       cli_sha: ${{ steps.release.outputs['apps/cli--sha'] }}
-      alias_release_created: ${{ steps.release.outputs['packages/rudel-alias--release_created'] }}
-      alias_tag_name: ${{ steps.release.outputs['packages/rudel-alias--tag_name'] }}
-      alias_sha: ${{ steps.release.outputs['packages/rudel-alias--sha'] }}
     steps:
       - name: Run Release Please
         id: release
@@ -58,8 +55,7 @@ jobs:
       always() &&
       (
         (
-          needs.release_please.outputs.cli_release_created == 'true' &&
-          needs.release_please.outputs.alias_release_created == 'true'
+          needs.release_please.outputs.cli_release_created == 'true'
         ) ||
         (
           github.event_name == 'workflow_dispatch' &&
@@ -80,42 +76,26 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.release_please.outputs.cli_sha || inputs.release_tag }}
 
-      - name: Authorize lockstep release source
+      - name: Authorize release source
         env:
-          ALIAS_RELEASE_SHA: ${{ needs.release_please.outputs.alias_sha }}
-          ALIAS_RELEASE_TAG: ${{ needs.release_please.outputs.alias_tag_name }}
           CLI_RELEASE_SHA: ${{ needs.release_please.outputs.cli_sha }}
           CLI_RELEASE_TAG: ${{ needs.release_please.outputs.cli_tag_name || inputs.release_tag }}
         run: |
           package_version="$(node -p "require('./apps/cli/package.json').version")"
-          alias_version="$(node -p "require('./packages/rudel-alias/package.json').version")"
-          alias_dependency="$(node -p "require('./packages/rudel-alias/package.json').dependencies['@opalinehq/cli']")"
           expected_cli_tag="opaline-cli@${package_version}"
-          expected_alias_tag="rudel@${package_version}"
 
-          test "${package_version}" = "${alias_version}"
-          test "${package_version}" = "${alias_dependency}"
           test "${CLI_RELEASE_TAG}" = "${expected_cli_tag}"
-          if [[ -n "${ALIAS_RELEASE_TAG}" ]]; then
-            test "${ALIAS_RELEASE_TAG}" = "${expected_alias_tag}"
-          fi
 
           git fetch --force --no-tags origin main:refs/remotes/origin/main
           git fetch --force --no-tags origin \
-            "refs/tags/${expected_cli_tag}:refs/tags/${expected_cli_tag}" \
-            "refs/tags/${expected_alias_tag}:refs/tags/${expected_alias_tag}"
+            "refs/tags/${expected_cli_tag}:refs/tags/${expected_cli_tag}"
 
           checked_out_sha="$(git rev-parse HEAD)"
           cli_tag_sha="$(git rev-parse "refs/tags/${expected_cli_tag}^{commit}")"
-          alias_tag_sha="$(git rev-parse "refs/tags/${expected_alias_tag}^{commit}")"
 
           test "${checked_out_sha}" = "${cli_tag_sha}"
-          test "${cli_tag_sha}" = "${alias_tag_sha}"
           if [[ -n "${CLI_RELEASE_SHA}" ]]; then
             test "${cli_tag_sha}" = "${CLI_RELEASE_SHA}"
-          fi
-          if [[ -n "${ALIAS_RELEASE_SHA}" ]]; then
-            test "${alias_tag_sha}" = "${ALIAS_RELEASE_SHA}"
           fi
           git merge-base --is-ancestor "${cli_tag_sha}" refs/remotes/origin/main
 
@@ -130,9 +110,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Require completed manual npm bootstrap
-        run: |
-          npm view @opalinehq/cli version >/dev/null
-          npm view rudel version >/dev/null
+        run: npm view @opalinehq/cli version >/dev/null
 
       - name: Verify
         run: bun run verify
@@ -158,13 +136,3 @@ jobs:
           done
           echo "@opalinehq/cli@${version} did not become available in time."
           exit 1
-
-      - name: Publish rudel alias with provenance
-        working-directory: packages/rudel-alias
-        run: |
-          version="$(node -p "require('./package.json').version")"
-          if npm view "rudel@${version}" version >/dev/null 2>&1; then
-            echo "rudel@${version} is already published."
-          else
-            npm publish --access public --provenance
-          fi

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,3 @@
 {
-	"apps/cli": "0.5.1",
-	"packages/rudel-alias": "0.5.1"
+	"apps/cli": "0.5.1"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,22 +8,12 @@
 		{
 			"type": "node-workspace",
 			"merge": false
-		},
-		{
-			"type": "linked-versions",
-			"groupName": "opaline-cli",
-			"components": ["opaline-cli", "rudel"]
 		}
 	],
 	"packages": {
 		"apps/cli": {
 			"release-type": "node",
 			"component": "opaline-cli",
-			"changelog-path": "CHANGELOG.md"
-		},
-		"packages/rudel-alias": {
-			"release-type": "node",
-			"component": "rudel",
 			"changelog-path": "CHANGELOG.md"
 		}
 	}


### PR DESCRIPTION
## Summary

- make Release Please track only the canonical `@opalinehq/cli` package
- remove the blocked `rudel@*` tag requirement and obsolete npm alias publish
- retain canonical tag/SHA/main-ancestry authorization, provenance publishing, verification, and registry availability checks

## Why

The active no-bypass ruleset intentionally prevents new `rudel@*` tags, while npm trusted publishing is not configured for the obsolete unscoped alias. Keeping that package in the linked release made every recovery impossible and caused Release Please to scan stale history toward `1.0.0` when its expected alias baseline was absent.

## Test plan

- [x] `bun run verify` — 672 tests passed, typecheck, Biome, and build green
- [x] parsed release workflow YAML and both Release Please JSON files
- [x] `git diff --check`
- [x] confirmed no stale alias release outputs or publish references remain

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790510458&installation_model_id=433970&pr_number=470&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F470&signature=58a71ffb502e66de8db5ef4ca11d99f3708967f4962c44b0d0ae58db3c77154c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->