### PR TITLE
fix(cli): support positional Codex uploads

### DIFF
--- a/apps/cli/src/__tests__/helpers/ingest-stub.ts
+++ b/apps/cli/src/__tests__/helpers/ingest-stub.ts
@@ -231,12 +231,29 @@ export async function createCliFixture(
 					sessionId,
 					payload: { id: sessionId, cwd: projectPath },
 				}),
-				JSON.stringify({
-					type: source === "codex" ? "message" : "user",
-					role: "human",
-					content: "endpoint security integration test",
-					timestamp: "2026-07-29T10:00:01.000Z",
-				}),
+				JSON.stringify(
+					source === "codex"
+						? {
+								timestamp: "2026-07-29T10:00:01.000Z",
+								type: "response_item",
+								payload: {
+									content: [
+										{
+											text: "endpoint security integration test",
+											type: "input_text",
+										},
+									],
+									role: "user",
+									type: "message",
+								},
+							}
+						: {
+								content: "endpoint security integration test",
+								role: "human",
+								timestamp: "2026-07-29T10:00:01.000Z",
+								type: "user",
+							},
+				),
 			].join("\n"),
 		),
 	]);

--- a/apps/cli/src/__tests__/packed-cli-smoke.integration.ts
+++ b/apps/cli/src/__tests__/packed-cli-smoke.integration.ts
@@ -133,6 +133,46 @@ test("clean upload succeeds and stamps the current filter_version on the wire", 
 	}
 }, 60_000);
 
+test("single-file Codex upload uses Codex metadata and adapter", async () => {
+	const packedCliPath = requirePackedCliPath();
+	const stub = startIngestStub();
+	const fixture = await createCliFixture("codex");
+	try {
+		const result = await runBuiltCli(
+			[
+				"upload",
+				fixture.transcriptPath,
+				"--endpoint",
+				`${stub.loopbackBase}/rpc`,
+			],
+			{
+				home: fixture.home,
+				configDir: fixtureConfigDir(fixture),
+				cliPath: packedCliPath,
+				env: { RUDEL_ALLOW_INSECURE_ENDPOINT: "" },
+			},
+		);
+
+		expect(result.exitCode, result.stderr).toBe(0);
+		expect(result.stdout).toContain("Upload successful!");
+		expect(result.stdout).toContain("Repository: project");
+		expect(stub.requests).toEqual([
+			{ apiKey: INGEST_STUB_TEST_TOKEN, pathname: "/rpc/ingestSession" },
+		]);
+		const wireBody = JSON.parse(stub.bodies[0] ?? "") as {
+			json?: { projectPath?: unknown; sessionId?: unknown; source?: unknown };
+		};
+		expect(wireBody.json).toMatchObject({
+			projectPath: fixture.projectPath,
+			sessionId: fixture.sessionId,
+			source: "codex",
+		});
+	} finally {
+		await stub.server.stop(true);
+		await rm(fixture.home, { recursive: true, force: true });
+	}
+}, 60_000);
+
 test("dirty upload is filtered client-side on this Node runtime", async () => {
 	// The test class that would have caught the Node 20 (?i:) filter crash:
 	// the packed artifact must compile every rule and redact on the ambient

--- a/apps/cli/src/__tests__/upload.integration.test.ts
+++ b/apps/cli/src/__tests__/upload.integration.test.ts
@@ -128,6 +128,46 @@ describe("session resolver", () => {
 		expect(result.transcriptPath).toBe(sessionFile);
 		expect(result.sessionId).toBe(sessionId);
 		expect(result.sessionDir).toBe(tempDir);
+		expect(result.source).toBe("claude_code");
+	});
+
+	test("resolves a Codex rollout path from session metadata", async () => {
+		const sessionId = "01a03d7a-9676-7021-8083-169df61d2142";
+		const projectPath = join(tempDir, "codex-project");
+		const sessionFile = join(
+			tempDir,
+			`rollout-2026-08-26T11-50-39-${sessionId}.jsonl`,
+		);
+		await writeFile(
+			sessionFile,
+			[
+				JSON.stringify({
+					timestamp: "2026-08-26T09:50:39.000Z",
+					type: "session_meta",
+					payload: {
+						id: sessionId,
+						cwd: projectPath,
+						git: { branch: "feat/codex", sha: "a".repeat(40) },
+					},
+				}),
+				JSON.stringify({
+					timestamp: "2026-08-26T09:50:40.000Z",
+					type: "response_item",
+					payload: { type: "message", role: "user", content: [] },
+				}),
+			].join("\n"),
+		);
+
+		const result = await resolveSession(sessionFile);
+
+		expect(result).toMatchObject({
+			gitBranch: "feat/codex",
+			gitSha: "a".repeat(40),
+			projectPath,
+			sessionId,
+			source: "codex",
+			transcriptPath: sessionFile,
+		});
 	});
 
 	test.skipIf(!hasClaudeProjects)(

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -1,4 +1,5 @@
 import { stat } from "node:fs/promises";
+import { basename } from "node:path";
 import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import pMap from "p-map";
@@ -647,7 +648,7 @@ async function runSingleUpload(
 	const displayName =
 		gitInfo.gitRemote ||
 		gitInfo.packageName ||
-		sessionInfo.projectPath.split("/").pop();
+		basename(sessionInfo.projectPath);
 	if (displayName) write(`Repository: ${displayName}`);
 	if (gitInfo.branch) write(`Branch: ${gitInfo.branch}`);
 

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -660,16 +660,21 @@ async function runSingleUpload(
 		sessionId: sessionInfo.sessionId,
 		transcriptPath: sessionInfo.transcriptPath,
 		projectPath: sessionInfo.projectPath,
+		gitBranch: sessionInfo.gitBranch,
+		gitSha: sessionInfo.gitSha,
 	};
 
 	let request: FileBackedUploadRequest;
 	try {
-		request = await claudeCodeAdapter.buildUploadRequest(sessionFile, {
-			tag: flags.tag,
-			gitInfo,
-			organizationId,
-			uploadMode: "manual",
-		});
+		request = await getAdapter(sessionInfo.source).buildUploadRequest(
+			sessionFile,
+			{
+				tag: flags.tag,
+				gitInfo,
+				organizationId,
+				uploadMode: "manual",
+			},
+		);
 	} catch (error) {
 		if (error instanceof MissingTranscriptTimestampError) {
 			return new Error(

--- a/apps/cli/src/internal/agent-adapters/adapters/codex/index.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/codex/index.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { scanBoundedJsonlFile } from "../../bounded-jsonl-scan.js";
 import { MissingTranscriptTimestampError } from "../../errors.js";
 import type {
@@ -91,6 +91,7 @@ export async function findActiveRolloutFile(
 	const files = await walkJsonlFiles(SESSIONS_BASE_DIR);
 
 	for (const filePath of files) {
+		if (!basename(filePath).includes(threadId)) continue;
 		const meta = await readCodexSessionMeta(filePath);
 		if (meta?.id === threadId) {
 			return filePath;

--- a/apps/cli/src/lib/session-resolver.ts
+++ b/apps/cli/src/lib/session-resolver.ts
@@ -1,7 +1,12 @@
 import { access, readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
-import { decodeProjectPath } from "../internal/agent-adapters/index.js";
+import type { Source } from "../contracts/index.js";
+import {
+	decodeProjectPath,
+	findActiveRolloutFile,
+	readCodexSessionMeta,
+} from "../internal/agent-adapters/index.js";
 
 export const SESSIONS_BASE_DIR = join(homedir(), ".claude", "projects");
 
@@ -10,6 +15,9 @@ export interface SessionInfo {
 	projectPath: string;
 	sessionDir: string;
 	sessionId: string;
+	source: Source;
+	gitBranch?: string;
+	gitSha?: string;
 }
 
 export async function resolveSession(input: string): Promise<SessionInfo> {
@@ -33,13 +41,31 @@ async function resolveFromPath(filePath: string): Promise<SessionInfo> {
 
 	const sessionId = filename.replace(/\.jsonl$/, "");
 	const sessionDir = dirname(filePath);
+	const codexMeta = await readCodexSessionMeta(filePath);
+	if (codexMeta) {
+		return {
+			transcriptPath: filePath,
+			projectPath: codexMeta.cwd,
+			sessionDir,
+			sessionId: codexMeta.id,
+			source: "codex",
+			gitBranch: codexMeta.gitBranch,
+			gitSha: codexMeta.gitSha,
+		};
+	}
 
 	// Walk up from sessionDir to find the project directory name
 	// Sessions live at: ~/.claude/projects/<encoded-project-dir>/<sessionId>.jsonl
 	const parentDir = basename(sessionDir);
 	const projectPath = await decodeProjectPath(parentDir);
 
-	return { transcriptPath: filePath, projectPath, sessionDir, sessionId };
+	return {
+		transcriptPath: filePath,
+		projectPath,
+		sessionDir,
+		sessionId,
+		source: "claude_code",
+	};
 }
 
 async function resolveFromId(sessionId: string): Promise<SessionInfo> {
@@ -65,9 +91,15 @@ async function resolveFromId(sessionId: string): Promise<SessionInfo> {
 					projectPath,
 					sessionDir,
 					sessionId,
+					source: "claude_code",
 				};
 			}
 		} catch {}
+	}
+
+	const codexTranscriptPath = await findActiveRolloutFile(sessionId);
+	if (codexTranscriptPath) {
+		return resolveFromPath(codexTranscriptPath);
 	}
 
 	throw new Error(`Session not found: ${sessionId}`);


### PR DESCRIPTION
## Summary
- detect Codex rollouts from session metadata in positional upload resolution
- dispatch explicit uploads through the matching agent adapter and preserve Codex git metadata
- make Codex rollout lookup skip unrelated transcripts before parsing
- add a real-shape packed-artifact regression test

## Root cause
`opaline upload <path>` always called the Claude adapter and decoded the Codex date directory as the repository. This rejected valid Codex rollouts as timestamp-less before any network request.

## Verification
- `tsc --noEmit -p apps/cli/tsconfig.json`
- `biome check .`
- CLI suite: 673 passed
- packed-artifact smoke: 10 passed
- exact 41.6 MB production transcript dry-run resolves `source: codex`, the metadata thread ID, Athena repository, branch, and SHA correctly

Consulted independently with Claude Fable 5/high; its root-cause analysis matched the reproduced failure and implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516028&installation_model_id=433970&pr_number=471&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F471&signature=ba3dd23b122eccb31598d6d10795b5983e6dbb3691a047f3e927855dd4951acc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->