### PR TITLE
fix: make Opaline uploads work from any directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # Print debug diagnostics for every command to stderr.
 # OPALINE_LOG_LEVEL=debug
 
-# Override the API base. Production defaults to https://app.rudel.ai.
+# Override the API base. Production defaults to https://opaline.so.
 # OPALINE_API_BASE=http://localhost:4010
 
 # Override the local state directory. By default Opaline intentionally keeps

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Opaline CLI
 
 Capture Claude Code and OpenAI Codex sessions and upload them to Opaline for
-team analytics. The production API remains at
-[`https://app.rudel.ai`](https://app.rudel.ai) during the Opaline migration.
+team analytics. The production API is at
+[`https://opaline.so`](https://opaline.so).
 
 ## Quick start
 
@@ -76,7 +76,7 @@ opaline disable
 
 ## Configuration
 
-The CLI defaults to the current production API at `https://app.rudel.ai`.
+The CLI defaults to the current production API at `https://opaline.so`.
 
 | Variable | Purpose |
 | --- | --- |
@@ -99,7 +99,7 @@ OPALINE_LOG_LEVEL=debug opaline doctor
 
 - **Not authenticated:** run `opaline login`. Existing credentials should be
   found automatically under `~/.rudel/credentials.json`.
-- **API unreachable:** confirm that `https://app.rudel.ai/health` is reachable
+- **API unreachable:** confirm that `https://opaline.so/health` is reachable
   and check `OPALINE_API_BASE`/`RUDEL_API_BASE` overrides.
 - **Hooks disabled:** run `opaline enable` from the project where the agent is
   used. Existing `rudel` hook commands are recognized and upgraded when the

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Existing `rudel` users do not need to log in again. Opaline intentionally reads
 the existing `~/.rudel` credential and state directory, and the `rudel` package
 continues as a compatibility alias.
 
+Run `opaline upload` from any directory, including your home folder. The picker
+finds saved sessions across repositories and uploads the repositories you select.
+It also enables automatic uploads for those selections. Claude Code's hook is
+installed in your user settings, so setup does not depend on your current
+directory. Existing hooks and settings are preserved.
+
 ## Typical workflow
 
 ```bash
@@ -101,8 +107,8 @@ OPALINE_LOG_LEVEL=debug opaline doctor
   found automatically under `~/.rudel/credentials.json`.
 - **API unreachable:** confirm that `https://opaline.so/health` is reachable
   and check `OPALINE_API_BASE`/`RUDEL_API_BASE` overrides.
-- **Hooks disabled:** run `opaline enable` from the project where the agent is
-  used. Existing `rudel` hook commands are recognized and upgraded when the
+- **Hooks disabled:** run `opaline upload` and select the repositories to enable.
+  Existing `rudel` hook commands are recognized and upgraded when the
   hook is installed again.
 - **Queued upload failures:** run `opaline upload --retry`. Permanent failures
   remain visible in `opaline whoami`.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -16,7 +16,7 @@ already have. `opaline enable` remains available to enable the current
 repository directly.
 
 The CLI keeps using the existing `~/.rudel` state directory so upgrades do not
-require another login. Its production API remains `https://app.rudel.ai`.
+require another login. Its production API is `https://opaline.so`.
 
 For commands, configuration, troubleshooting, and the full security/data
 handling disclosure, see the

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,7 @@
 	"engines": {
 		"node": ">=20"
 	},
-	"homepage": "https://app.rudel.ai",
+	"homepage": "https://opaline.so",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/opalinehq/cli.git",

--- a/apps/cli/src/__tests__/api-base.test.ts
+++ b/apps/cli/src/__tests__/api-base.test.ts
@@ -66,7 +66,7 @@ describe("resolveApiBase", () => {
 		).toBe("http://internal.example");
 	});
 
-	test.each(["http://localhost:4010", "https://app.rudel.ai"])(
+	test.each(["http://localhost:4010", "https://opaline.so"])(
 		"accepts %p with neither the flag nor the env var",
 		(input) => {
 			delete process.env[ENV_VAR];
@@ -83,9 +83,9 @@ describe("resolveApiBase", () => {
 		// Otherwise `${apiBase}/api/auth/device/code` gains a doubled slash.
 		expect(
 			acceptedUrl(
-				resolveApiBase("https://app.rudel.ai/", allowsPlaintext(false)),
+				resolveApiBase("https://opaline.so/", allowsPlaintext(false)),
 			),
-		).toBe("https://app.rudel.ai");
+		).toBe("https://opaline.so");
 	});
 
 	test("still refuses a non-http scheme when the override is set", () => {
@@ -165,7 +165,7 @@ describe("describeLogoutApiBaseRisk", () => {
 		);
 	});
 
-	test.each(["https://app.rudel.ai", "http://localhost:4010"])(
+	test.each(["https://opaline.so", "http://localhost:4010"])(
 		"stays silent for %p",
 		(storedApiBase) => {
 			expect(describeLogoutApiBaseRisk(storedApiBase)).toBeUndefined();
@@ -188,7 +188,7 @@ describe("describeStoredApiBaseRisk", () => {
 		expect(describeStoredApiBaseRisk("http://internal.example")).toBeString();
 	});
 
-	test.each(["https://app.rudel.ai", "http://localhost:4010"])(
+	test.each(["https://opaline.so", "http://localhost:4010"])(
 		"stays silent for %p",
 		(storedApiBase) => {
 			expect(describeStoredApiBaseRisk(storedApiBase)).toBeUndefined();

--- a/apps/cli/src/__tests__/browser-opener.test.ts
+++ b/apps/cli/src/__tests__/browser-opener.test.ts
@@ -9,14 +9,14 @@ describe("resolveBrowserOpener", () => {
 		// a command separator. The invariant is that no fragment of the URL appears
 		// in the command or its arguments — it may only travel via the environment,
 		// which nothing parses.
-		const url = "https://app.rudel.ai/device?user_code=X&calc";
+		const url = "https://opaline.so/device?user_code=X&calc";
 		const { command, args } = resolveBrowserOpener("win32", url);
 
 		expect(command).not.toBe("cmd");
 		expect(command).not.toBe("cmd.exe");
 		expect(command).not.toContain("rundll32");
 		for (const arg of args) {
-			expect(arg).not.toContain("app.rudel.ai");
+			expect(arg).not.toContain("opaline.so");
 			expect(arg).not.toContain("user_code");
 			expect(arg).not.toContain("&");
 		}
@@ -26,7 +26,7 @@ describe("resolveBrowserOpener", () => {
 		// explorer.exe silently ignores http URLs with a query string, so the
 		// opener ShellExecutes through Start-Process with the URL in an env var.
 		// Plain -Command text, never the EDR-flagged -EncodedCommand pattern.
-		const url = "https://app.rudel.ai/device?user_code=X&calc";
+		const url = "https://opaline.so/device?user_code=X&calc";
 		const { command, args, detach, env } = resolveBrowserOpener("win32", url);
 
 		expect(command).toBe("powershell.exe");
@@ -43,7 +43,7 @@ describe("resolveBrowserOpener", () => {
 		["linux", "xdg-open"],
 		["freebsd", "xdg-open"],
 	])("uses %p opener %p", (platform, expected) => {
-		const url = "https://app.rudel.ai/device?user_code=X";
+		const url = "https://opaline.so/device?user_code=X";
 		const { command, args, detach, env } = resolveBrowserOpener(platform, url);
 
 		expect(command).toBe(expected);
@@ -57,29 +57,29 @@ describe("buildVerificationUrl", () => {
 	test("prefers the server-supplied complete URL", () => {
 		expect(
 			buildVerificationUrl({
-				verification_uri: "https://app.rudel.ai/device",
+				verification_uri: "https://opaline.so/device",
 				verification_uri_complete:
-					"https://app.rudel.ai/device?user_code=ABCD1234",
+					"https://opaline.so/device?user_code=ABCD1234",
 				user_code: "ABCD1234",
 			}),
-		).toBe("https://app.rudel.ai/device?user_code=ABCD1234");
+		).toBe("https://opaline.so/device?user_code=ABCD1234");
 	});
 
 	test("appends the user code when no complete URL is supplied", () => {
 		expect(
 			buildVerificationUrl({
-				verification_uri: "https://app.rudel.ai/device",
+				verification_uri: "https://opaline.so/device",
 				verification_uri_complete: undefined,
 				user_code: "ABCD1234",
 			}),
-		).toBe("https://app.rudel.ai/device?user_code=ABCD1234");
+		).toBe("https://opaline.so/device?user_code=ABCD1234");
 	});
 
 	test("does not corrupt a verification URI that already has a query string", () => {
 		// Regression test: `?`-concatenation produced two `?` separators and a
 		// malformed URL. Reachable via CLI_DEVICE_VERIFICATION_URL.
 		const built = buildVerificationUrl({
-			verification_uri: "https://app.rudel.ai/device?tenant=acme",
+			verification_uri: "https://opaline.so/device?tenant=acme",
 			verification_uri_complete: undefined,
 			user_code: "ABCD1234",
 		});
@@ -91,7 +91,7 @@ describe("buildVerificationUrl", () => {
 
 	test("percent-encodes a user code containing URL-significant characters", () => {
 		const built = buildVerificationUrl({
-			verification_uri: "https://app.rudel.ai/device",
+			verification_uri: "https://opaline.so/device",
 			verification_uri_complete: undefined,
 			user_code: "AB&CD=EF",
 		});

--- a/apps/cli/src/__tests__/claude-hook-settings.integration.test.ts
+++ b/apps/cli/src/__tests__/claude-hook-settings.integration.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const fixtureHomes: string[] = [];
+const hookCommand = "opaline hooks claude session-end";
+const otherHook = { type: "command", command: "echo keep-existing-hook" };
+
+afterAll(async () => {
+	await Promise.all(
+		fixtureHomes.map((home) => rm(home, { recursive: true, force: true })),
+	);
+});
+
+test("installs once in user settings and can disable from another repository", async () => {
+	const home = await mkdtemp(join(tmpdir(), "opaline-global-hook-"));
+	fixtureHomes.push(home);
+	const first = join(home, "first-repository");
+	const second = join(home, "second-repository");
+	const settingsPath = join(home, ".claude", "settings.json");
+	await mkdir(join(home, ".claude"));
+	await mkdir(join(first, ".claude"), { recursive: true });
+	await mkdir(second);
+	const projectSettings = '{"permissions":{"allow":["Read"]}}\n';
+	await writeFile(join(first, ".claude", "settings.json"), projectSettings);
+	const original = {
+		permissions: { deny: ["Read(.env)"] },
+		hooks: { SessionEnd: [{ matcher: "", hooks: [otherHook] }] },
+	};
+	await writeFile(settingsPath, JSON.stringify(original));
+
+	expect(await runProbe("install", home, first)).toEqual({
+		path: settingsPath,
+		enabled: true,
+	});
+	const installed = await readFile(settingsPath, "utf8");
+	expect(JSON.parse(installed)).toEqual({
+		...original,
+		hooks: {
+			SessionEnd: [
+				{ matcher: "", hooks: [otherHook] },
+				{
+					matcher: "",
+					hooks: [{ type: "command", command: hookCommand, async: true }],
+				},
+			],
+		},
+	});
+	expect(await runProbe("install", home, second)).toEqual({
+		path: settingsPath,
+		enabled: true,
+	});
+	expect(await readFile(settingsPath, "utf8")).toBe(installed);
+	expect(await readFile(join(first, ".claude", "settings.json"), "utf8")).toBe(
+		projectSettings,
+	);
+	expect(await runProbe("remove", home, second)).toEqual({
+		path: settingsPath,
+		enabled: false,
+	});
+	expect(JSON.parse(await readFile(settingsPath, "utf8"))).toEqual(original);
+});
+
+test("upgrades a legacy user hook and preserves neighboring hooks on removal", async () => {
+	const home = await mkdtemp(join(tmpdir(), "opaline-legacy-hook-"));
+	fixtureHomes.push(home);
+	await mkdir(join(home, ".claude"));
+	const settingsPath = join(home, ".claude", "settings.json");
+	await writeFile(
+		settingsPath,
+		JSON.stringify({
+			hooks: {
+				SessionEnd: [
+					{
+						matcher: "",
+						hooks: [
+							otherHook,
+							{ type: "command", command: "rudel hooks claude session-end" },
+						],
+					},
+				],
+			},
+		}),
+	);
+	await runProbe("install", home, home);
+	expect(JSON.parse(await readFile(settingsPath, "utf8"))).toEqual({
+		hooks: {
+			SessionEnd: [
+				{
+					matcher: "",
+					hooks: [otherHook, { type: "command", command: hookCommand }],
+				},
+			],
+		},
+	});
+	await runProbe("remove", home, home);
+	expect(JSON.parse(await readFile(settingsPath, "utf8"))).toEqual({
+		hooks: { SessionEnd: [{ matcher: "", hooks: [otherHook] }] },
+	});
+});
+
+async function runProbe(
+	action: string,
+	home: string,
+	cwd: string,
+): Promise<unknown> {
+	const child = Bun.spawn(
+		[
+			process.execPath,
+			join(import.meta.dir, "helpers/claude-hook-settings-probe.ts"),
+			action,
+		],
+		{
+			cwd,
+			env: { ...process.env, HOME: home, USERPROFILE: home },
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stderr).toBe("");
+	return JSON.parse(stdout);
+}

--- a/apps/cli/src/__tests__/config-migration.test.ts
+++ b/apps/cli/src/__tests__/config-migration.test.ts
@@ -26,6 +26,7 @@ describe("Rudel config compatibility", () => {
 				token: "fixture-token",
 				apiBaseUrl: "https://app.rudel.ai",
 				authType: "api-key",
+				apiKeyId: "fixture-key-id",
 			}),
 			{ mode: 0o600 },
 		);
@@ -34,12 +35,30 @@ describe("Rudel config compatibility", () => {
 		expect(info.source).toBe("rudel-default");
 		expect(loadCredentials("read-only", info.directory)).toEqual({
 			token: "fixture-token",
-			apiBaseUrl: "https://app.rudel.ai",
+			apiBaseUrl: "https://opaline.so",
 			authType: "api-key",
-			apiKeyId: undefined,
+			apiKeyId: "fixture-key-id",
 			user: undefined,
 			organizations: undefined,
 		});
+	});
+
+	test("preserves a custom credential API base", async () => {
+		const customDirectory = join(fixtureHome, "custom");
+		await mkdir(customDirectory, { recursive: true, mode: 0o700 });
+		await writeFile(
+			join(customDirectory, "credentials.json"),
+			JSON.stringify({
+				token: "fixture-token",
+				apiBaseUrl: "https://opaline.internal.example/base",
+				authType: "api-key",
+			}),
+			{ mode: 0o600 },
+		);
+
+		expect(loadCredentials("read-only", customDirectory)?.apiBaseUrl).toBe(
+			"https://opaline.internal.example/base",
+		);
 	});
 
 	test("ignores the dead Gazed config path", async () => {

--- a/apps/cli/src/__tests__/credentials-security.test.ts
+++ b/apps/cli/src/__tests__/credentials-security.test.ts
@@ -111,6 +111,24 @@ test("repairs existing permissions and atomically replaces credentials", () => {
 	}
 });
 
+test("canonicalizes the legacy production API base when saving credentials", () => {
+	const configDir = join(tempRoot, "save-legacy-production-base");
+
+	withConfigDir(configDir, () =>
+		saveCredentials({
+			token: NEW_TOKEN,
+			apiBaseUrl: "https://app.rudel.ai/",
+		}),
+	);
+
+	expect(
+		JSON.parse(readFileSync(join(configDir, "credentials.json"), "utf8")),
+	).toEqual({
+		token: NEW_TOKEN,
+		apiBaseUrl: "https://opaline.so",
+	});
+});
+
 test("repairs existing permissions before loading credentials", () => {
 	const configDir = join(tempRoot, "load");
 	const credentialsPath = preparePermissiveCredentials(configDir);

--- a/apps/cli/src/__tests__/helpers/claude-hook-settings-probe.ts
+++ b/apps/cli/src/__tests__/helpers/claude-hook-settings-probe.ts
@@ -1,0 +1,12 @@
+import {
+	addHook,
+	getClaudeSettingsPath,
+	isHookEnabled,
+	removeHook,
+} from "../../internal/agent-adapters/adapters/claude-code/settings.js";
+
+if (process.argv[2] === "install") addHook();
+if (process.argv[2] === "remove") removeHook();
+console.log(
+	JSON.stringify({ path: getClaudeSettingsPath(), enabled: isHookEnabled() }),
+);

--- a/apps/cli/src/__tests__/login-env.test.ts
+++ b/apps/cli/src/__tests__/login-env.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { getDefaultApiBase } from "../lib/api-target.js";
+import { DEFAULT_ENDPOINT } from "../lib/types.js";
 
 const originalApiBase = process.env.RUDEL_API_BASE;
 
@@ -15,7 +16,7 @@ describe("login environment defaults", () => {
 	test("defaults to production when no local override is configured", () => {
 		delete process.env.RUDEL_API_BASE;
 
-		expect(getDefaultApiBase()).toBe("https://app.rudel.ai");
+		expect(getDefaultApiBase()).toBe("https://opaline.so");
 	});
 
 	test("uses RUDEL_API_BASE for local device login", () => {
@@ -23,4 +24,8 @@ describe("login environment defaults", () => {
 
 		expect(getDefaultApiBase()).toBe("http://localhost:4010");
 	});
+});
+
+test("defaults transcript uploads to the canonical production RPC endpoint", () => {
+	expect(DEFAULT_ENDPOINT).toBe("https://opaline.so/rpc");
 });

--- a/apps/cli/src/__tests__/r2-upload-flow.test.ts
+++ b/apps/cli/src/__tests__/r2-upload-flow.test.ts
@@ -470,7 +470,7 @@ describe("capability-gated R2 upload flow", () => {
 		expect(requestPaths).toEqual([]);
 	});
 
-	test("streams a 100+ MiB adapter request through filtering, init, and multipart with bounded heap and RSS", async () => {
+	test("probes R2 for a first 100+ MiB adapter upload without a capability cache", async () => {
 		await isolateCapabilityCache();
 		const directory = await mkdtemp(join(tmpdir(), "opaline-r2-e2e-large-"));
 		temporaryDirectories.push(directory);
@@ -578,12 +578,6 @@ describe("capability-gated R2 upload flow", () => {
 		});
 		activeServers.push(server);
 		const config = createUploadConfig(server);
-		const warmup = await uploadSession(
-			createRequest("large-r2-warmup", "clean"),
-			config,
-		);
-		expect(warmup.success).toBe(true);
-		requestPaths.length = 0;
 
 		const probePath = join(
 			import.meta.dir,
@@ -654,7 +648,7 @@ describe("capability-gated R2 upload flow", () => {
 				"bun",
 				probePath,
 				transcriptPath,
-				"https://app.rudel.ai/rpc",
+				"https://opaline.so/rpc",
 				TOKEN,
 				"oversized-record-codex-session",
 			],
@@ -681,7 +675,7 @@ describe("capability-gated R2 upload flow", () => {
 		expect(memory.requestPaths).toEqual([]);
 	}, 120_000);
 
-	test("keeps a 100+ MiB failed R2 init bounded and retryable without legacy fallback", async () => {
+	test("keeps a first 100+ MiB transient R2 init retryable without legacy fallback", async () => {
 		await isolateCapabilityCache();
 		const directory = await mkdtemp(
 			join(tmpdir(), "opaline-r2-failed-init-large-"),
@@ -726,12 +720,6 @@ describe("capability-gated R2 upload flow", () => {
 		});
 		activeServers.push(server);
 		const config = createUploadConfig(server);
-		const warmup = await uploadSession(
-			createRequest("failed-init-r2-warmup", "clean"),
-			config,
-		);
-		expect(warmup.success).toBe(true);
-		requestPaths.length = 0;
 
 		const probePath = join(
 			import.meta.dir,
@@ -786,7 +774,7 @@ describe("capability-gated R2 upload flow", () => {
 				"api-key",
 				TOKEN,
 			),
-		).toBe(true);
+		).toBe(false);
 	}, 120_000);
 
 	test("rejects an empty main transcript locally before any R2 request", async () => {
@@ -819,7 +807,7 @@ describe("capability-gated R2 upload flow", () => {
 		expect(requestCount).toBe(0);
 	});
 
-	test("rejects a file-backed transcript above the safe legacy materialization cap", async () => {
+	test("probes R2 for a first oversized upload and falls back on an unsupported server", async () => {
 		await isolateCapabilityCache();
 		const directory = await mkdtemp(join(tmpdir(), "opaline-r2-legacy-cap-"));
 		temporaryDirectories.push(directory);
@@ -850,11 +838,6 @@ describe("capability-gated R2 upload flow", () => {
 		});
 		activeServers.push(server);
 		const config = createUploadConfig(server);
-		await rememberR2UploadCapability(
-			new URL(config.endpoint),
-			"api-key",
-			TOKEN,
-		);
 
 		const result = await uploadSession(
 			createFileRequest("legacy-too-large", transcriptPath),

--- a/apps/cli/src/__tests__/upload-organization.test.ts
+++ b/apps/cli/src/__tests__/upload-organization.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { getDefaultUploadOrganizationId } from "../lib/upload-organization.js";
+
+test("prefers the personal workspace when it is among multiple memberships", () => {
+	expect(
+		getDefaultUploadOrganizationId([{ id: "team" }, { id: "user" }], "user"),
+	).toBe("user");
+});
+
+test("uses a sole legacy workspace whose ID differs from the user's ID", () => {
+	expect(getDefaultUploadOrganizationId([{ id: "legacy" }], "user")).toBe(
+		"legacy",
+	);
+});
+
+test("requires a choice for multiple workspaces without a personal default", () => {
+	expect(
+		getDefaultUploadOrganizationId(
+			[{ id: "team-a" }, { id: "team-b" }],
+			"user",
+		),
+	).toBeUndefined();
+});
+
+test("leaves resolution to the server when no memberships were saved", () => {
+	expect(getDefaultUploadOrganizationId([], undefined)).toBeUndefined();
+});

--- a/apps/cli/src/commands/set-org.ts
+++ b/apps/cli/src/commands/set-org.ts
@@ -1,6 +1,7 @@
 import * as p from "@clack/prompts";
 import { buildCommand } from "@stricli/core";
 import { createApiClient } from "../lib/api-client.js";
+import { PRODUCTION_API_BASE } from "../lib/api-target.js";
 import { loadCredentials } from "../lib/credentials.js";
 import { getProjectOrgId, setProjectOrgId } from "../lib/project-config.js";
 
@@ -26,7 +27,7 @@ async function runSetOrg(): Promise<undefined | Error> {
 	}
 
 	if (orgs.length === 0) {
-		p.outro("Create one at app.rudel.ai first.");
+		p.outro(`Create one at ${PRODUCTION_API_BASE} first.`);
 		return new Error("No organizations found.");
 	}
 

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -33,7 +33,7 @@ import {
 	removeFailedUpload,
 } from "../lib/failed-uploads.js";
 import { type GitInfo, getGitInfo } from "../lib/git-info.js";
-import { getProjectOrgId } from "../lib/project-config.js";
+import { getProjectOrgId, setProjectOrgId } from "../lib/project-config.js";
 import { scanAndGroupProjects } from "../lib/project-grouping.js";
 import { resolveSession } from "../lib/session-resolver.js";
 import {
@@ -42,6 +42,7 @@ import {
 	type SessionTag,
 } from "../lib/types.js";
 import { allowsInsecureEndpoint } from "../lib/upload-endpoint.js";
+import { getDefaultUploadOrganizationId } from "../lib/upload-organization.js";
 import {
 	groupUploadProjectsByRepository,
 	orderUploadRepositoriesNewFirst,
@@ -123,7 +124,38 @@ async function runInteractiveUpload(
 		(project) => prepareUploadTarget(project, flags.org),
 		{ concurrency: 10 },
 	);
-	const targets = preparedTargets.map((prepared) => prepared.target);
+	const organizations = credentials?.organizations ?? [];
+	let defaultOrganizationId = getDefaultUploadOrganizationId(
+		organizations,
+		credentials?.user?.id,
+	);
+	if (
+		preparedTargets.some(
+			(prepared) => prepared.target.organizationId === undefined,
+		) &&
+		defaultOrganizationId === undefined &&
+		organizations.length > 1
+	) {
+		spin.stop("Projects found");
+		const selected = await p.select({
+			message:
+				"Choose a workspace for repositories without a saved destination",
+			options: organizations.map((organization) => ({
+				value: organization.id,
+				label: organization.name,
+			})),
+		});
+		if (p.isCancel(selected)) {
+			p.cancel("Upload cancelled.");
+			return;
+		}
+		defaultOrganizationId = selected;
+		spin.start("Checking uploaded sessions...");
+	}
+	const targets = preparedTargets.map(({ target }) => ({
+		...target,
+		organizationId: target.organizationId ?? defaultOrganizationId,
+	}));
 	const metadataByProject = new Map<ScannedProject, UploadProjectMetadata>();
 	for (const prepared of preparedTargets) {
 		metadataByProject.set(prepared.target.project, prepared.metadata);
@@ -145,6 +177,7 @@ async function runInteractiveUpload(
 		}
 		uploadProjects = reconciled.map((project) => ({
 			...project,
+			organizationId: project.resolvedOrganizationId,
 			...getUploadProjectMetadata(metadataByProject, project.project),
 			statusKnown: true,
 		}));
@@ -280,6 +313,16 @@ async function runInteractiveUpload(
 
 	if (!credentials) {
 		return new Error("Not authenticated. Run `opaline login` first.");
+	}
+	for (const repository of selectedRepositories) {
+		for (const project of repository.projects) {
+			if (project.organizationId) {
+				await setProjectOrgId(
+					project.project.projectPath,
+					project.organizationId,
+				);
+			}
+		}
 	}
 	const savedAutoUploadConfig = saveVisibleAutoUploadSelections(
 		orderedRepositories.map(toAutoUploadRepositorySelection),

--- a/apps/cli/src/contracts/safe-url.ts
+++ b/apps/cli/src/contracts/safe-url.ts
@@ -18,7 +18,7 @@
  *
  * IMPORTANT: parsing alone does NOT make a URL safe to hand to cmd.exe. `&`,
  * `|`, `(`, `)` and (in a query) `^` all survive WHATWG URL serialization, so
- * `https://app.rudel.ai/device?user_code=X&calc` passes every check here while
+ * `https://opaline.so/device?user_code=X&calc` passes every check here while
  * still injecting on Windows. That is why the Windows opener must not use a
  * shell at all — this validator and the shell-free opener are complementary,
  * not alternatives, and they cover disjoint platforms.
@@ -118,7 +118,7 @@ function validateCommon(input: string): SafeUrlResult {
 		};
 	}
 
-	// `https://app.rudel.ai@evil.example/device` resolves to evil.example while
+	// `https://opaline.so@evil.example/device` resolves to evil.example while
 	// reading as the real host. We print this URL for the user to copy, so
 	// userinfo is a spoofing vector, not just a credential-leak one.
 	if (parsed.username !== "" || parsed.password !== "") {

--- a/apps/cli/src/internal/agent-adapters/adapters/claude-code/settings.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/claude-code/settings.ts
@@ -1,6 +1,6 @@
-import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 
 const HOOK_COMMAND = "opaline hooks claude session-end";
 const LEGACY_HOOK_COMMAND = "rudel hooks claude session-end";
@@ -24,30 +24,8 @@ interface ClaudeSettings {
 	[key: string]: unknown;
 }
 
-function findClaudeDir(): string {
-	let dir = resolve(process.cwd());
-
-	while (dir !== dirname(dir)) {
-		const candidate = join(dir, ".claude");
-		if (existsSync(candidate)) {
-			return candidate;
-		}
-		dir = dirname(dir);
-	}
-
-	try {
-		const gitRoot = execSync("git rev-parse --show-toplevel", {
-			encoding: "utf-8",
-			stdio: ["pipe", "pipe", "pipe"],
-		}).trim();
-		return join(gitRoot, ".claude");
-	} catch {
-		return join(resolve(process.cwd()), ".claude");
-	}
-}
-
 export function getClaudeSettingsPath(): string {
-	return join(findClaudeDir(), "settings.json");
+	return join(homedir(), ".claude", "settings.json");
 }
 
 export function readClaudeSettings(): ClaudeSettings {
@@ -106,9 +84,12 @@ export function removeHook(): void {
 	const entries = hooks?.SessionEnd;
 	if (!hooks || !Array.isArray(entries)) return;
 
-	hooks.SessionEnd = entries.filter(
-		(entry) => !entry.hooks?.some((hook) => isOpalineHookCommand(hook.command)),
-	);
+	hooks.SessionEnd = entries
+		.map((entry) => ({
+			...entry,
+			hooks: entry.hooks.filter((hook) => !isOpalineHookCommand(hook.command)),
+		}))
+		.filter((entry) => entry.hooks.length > 0);
 
 	if (hooks.SessionEnd.length === 0) {
 		delete hooks.SessionEnd;

--- a/apps/cli/src/lib/api-target.ts
+++ b/apps/cli/src/lib/api-target.ts
@@ -1,4 +1,12 @@
-export const PRODUCTION_API_BASE = "https://app.rudel.ai";
+export const PRODUCTION_API_BASE = "https://opaline.so";
+const LEGACY_PRODUCTION_API_BASE = "https://app.rudel.ai";
+
+export function normalizeLegacyProductionApiBase(apiBaseUrl: string): string {
+	return apiBaseUrl === LEGACY_PRODUCTION_API_BASE ||
+		apiBaseUrl === `${LEGACY_PRODUCTION_API_BASE}/`
+		? PRODUCTION_API_BASE
+		: apiBaseUrl;
+}
 
 export function getApiBaseOverride(
 	environment: NodeJS.ProcessEnv = process.env,

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -10,6 +10,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { normalizeLegacyProductionApiBase } from "./api-target.js";
 import { debugLog } from "./debug.js";
 import { getConfigDir } from "./local-state.js";
 
@@ -38,7 +39,14 @@ export type CredentialReadMode = "secure" | "read-only";
 export function saveCredentials(credentials: Credentials): void {
 	const dir = getConfigDir();
 	const path = getCredentialsPath(dir);
-	const content = JSON.stringify(credentials, null, 2);
+	const content = JSON.stringify(
+		{
+			...credentials,
+			apiBaseUrl: normalizeLegacyProductionApiBase(credentials.apiBaseUrl),
+		},
+		null,
+		2,
+	);
 	debugLog("saving credentials", { path });
 
 	mkdirSync(dir, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
@@ -97,7 +105,7 @@ function parseCredentials(content: string): Credentials {
 
 	return {
 		token,
-		apiBaseUrl,
+		apiBaseUrl: normalizeLegacyProductionApiBase(apiBaseUrl),
 		authType,
 		apiKeyId,
 		user,

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { RedactionCounts } from "../internal/secret-filter/index.js";
+import { PRODUCTION_API_BASE } from "./api-target.js";
 
 export type SessionTag =
 	| "research"
@@ -36,4 +37,4 @@ export interface UploadResult {
 	usageChecksum?: string;
 }
 
-export const DEFAULT_ENDPOINT = "https://app.rudel.ai/rpc";
+export const DEFAULT_ENDPOINT = `${PRODUCTION_API_BASE}/rpc`;

--- a/apps/cli/src/lib/upload-organization.ts
+++ b/apps/cli/src/lib/upload-organization.ts
@@ -1,0 +1,12 @@
+export function getDefaultUploadOrganizationId(
+	organizations: readonly { id: string }[],
+	userId: string | undefined,
+): string | undefined {
+	const personal = organizations.find(
+		(organization) => organization.id === userId,
+	);
+	return (
+		personal?.id ??
+		(organizations.length === 1 ? organizations[0]?.id : undefined)
+	);
+}

--- a/apps/cli/src/lib/uploader.ts
+++ b/apps/cli/src/lib/uploader.ts
@@ -368,10 +368,11 @@ export async function uploadSession(
 	const client: ContractRouterClient<typeof contract> = createORPCClient(link);
 	const authType = config.authType ?? "bearer";
 	const endpointUrl = new URL(endpoint.url);
-	if (
+	const shouldProbeR2 =
 		authType === "api-key" &&
-		hasAdvertisedR2UploadCapability(endpointUrl, authType, config.token)
-	) {
+		(hasAdvertisedR2UploadCapability(endpointUrl, authType, config.token) ||
+			(await exceedsLegacyMaterializationLimit(request)));
+	if (authType === "api-key" && shouldProbeR2) {
 		try {
 			const r2Result = await uploadSessionViaR2(request, {
 				authType,
@@ -638,6 +639,16 @@ async function getFileBackedAggregateBytes(
 		...request.subagents.map((subagent) => stat(subagent.path)),
 	]);
 	return files.reduce((total, file) => total + file.size, 0);
+}
+
+async function exceedsLegacyMaterializationLimit(
+	request: UploadSessionRequest,
+): Promise<boolean> {
+	if (!isFileBackedUploadRequest(request)) return false;
+	return (
+		(await getFileBackedAggregateBytes(request)) >
+		LEGACY_MATERIALIZATION_MAX_BYTES
+	);
 }
 
 async function materializeLegacyUploadRequest(


### PR DESCRIPTION
Make `https://opaline.so` the CLI's production login and upload host, and migrate exact saved `app.rudel.ai` credentials while preserving tokens and custom endpoints. Probe direct R2 support for a first oversized upload before applying the legacy upload limit.

Install Claude Code's upload hook in user settings so `opaline upload` can select repositories from any directory. Preserve unrelated settings and hooks when installing, upgrading, or removing the Opaline hook. Repository selections still gate automatic uploads.

Resolve a personal or sole saved workspace before reconciliation, prompt when multiple destinations need a choice, and persist selected repositories' resolved destinations for future hooks.

Validation: full `bun run verify` passed (682 tests, TypeScript, Biome, and build). Added real-filesystem subprocess tests for installation from a repository, repeat installation from another directory, legacy hook upgrade, and preservation of neighboring hooks.

Backend dependency opalinehq/athena#42 is merged and deployed. The production upload-status endpoint now responds successfully to authenticated requests.
