### PR TITLE
feat: guide CLI onboarding before login and repair analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,20 @@
 # This sends transcript data and API credentials without transport encryption.
 # OPALINE_ALLOW_INSECURE_ENDPOINT=1
 
-# Optional product analytics. Disabled unless explicitly enabled and configured.
+# Published releases include public PostHog capture configuration.
+# Either switch disables capture. Source checkouts remain disabled by default.
+# DO_NOT_TRACK=1
 # POSTHOG_ENABLED=false
+# Explicit configuration for development or a different analytics project:
+# POSTHOG_ENABLED=true
 # POSTHOG_KEY=
 # POSTHOG_HOST=https://us.i.posthog.com
+
+# Release build inputs, embedded into both published Node entry points.
+# Use only a public phc_ project token, never a personal or secret API key.
+# Both must be supplied together; the npm release job requires them.
+# OPALINE_BUILD_POSTHOG_KEY=phc_your_public_project_token
+# OPALINE_BUILD_POSTHOG_HOST=https://us.i.posthog.com
 
 # Compatibility aliases accepted by the renamed CLI:
 # RUDEL_API_BASE=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,12 +117,18 @@ jobs:
 
       - name: Publish @opalinehq/cli with provenance
         working-directory: apps/cli
+        env:
+          OPALINE_BUILD_POSTHOG_KEY: ${{ vars.OPALINE_BUILD_POSTHOG_KEY }}
+          OPALINE_BUILD_POSTHOG_HOST: ${{ vars.OPALINE_BUILD_POSTHOG_HOST }}
         run: |
+          test -n "${OPALINE_BUILD_POSTHOG_KEY}"
+          test -n "${OPALINE_BUILD_POSTHOG_HOST}"
           version="$(node -p "require('./package.json').version")"
           if npm view "@opalinehq/cli@${version}" version >/dev/null 2>&1; then
             echo "@opalinehq/cli@${version} is already published."
           else
-            npm publish --access public --provenance
+            bun run build
+            npm publish --ignore-scripts --access public --provenance
           fi
 
       - name: Wait for @opalinehq/cli registry availability

--- a/README.md
+++ b/README.md
@@ -9,10 +9,21 @@ team analytics. The production API is at
 Requires Node.js 20 or newer.
 
 ```bash
-npm install --global @opalinehq/cli
-opaline login
-opaline upload
+npx @opalinehq/cli@latest
 ```
+
+Run this from any directory. The CLI scans local Claude Code and Codex sessions,
+shows repository and session counts, and lets you choose which repos to upload
+and keep syncing. Login opens only after selection. `pnpx @opalinehq/cli@latest`
+works too. A global install remains optional.
+
+Copying the command from the Opaline demo adds a hidden `--code` value. That
+one-time code pairs the terminal with your browser for live selection and upload
+status. It expires after ten minutes if unused. Approve login in the same browser
+where you copied the command; finishing setup opens your own Sessions page.
+
+Automatic uploads retain the bundled CLI under `~/.rudel/runtime` and use your
+Node executable, so hooks keep working after the temporary runner cache is gone.
 
 `opaline login` opens a browser-based device flow. `opaline upload` groups local
 worktrees by repository, lets you choose which repositories stay synchronized,
@@ -68,6 +79,8 @@ opaline disable
 
 | Command | Description |
 | --- | --- |
+| `opaline` / `opaline connect` | Scan, select repositories, then log in and upload. |
+| `opaline --code <code>` | Connect to the demo that supplied the copied command. |
 | `opaline login` | Authenticate through the browser device flow. |
 | `opaline logout` | Revoke the current credential and log out locally. |
 | `opaline whoami` | Show the authenticated user and local upload failures. |
@@ -91,6 +104,7 @@ The CLI defaults to the current production API at `https://opaline.so`.
 | `OPALINE_CONFIG_DIR` | Override local state; legacy `RUDEL_CONFIG_DIR` is also accepted. |
 | `OPALINE_ALLOW_INSECURE_API_BASE=1` | Permit plaintext non-loopback login/auth traffic. |
 | `OPALINE_ALLOW_INSECURE_ENDPOINT=1` | Permit plaintext non-loopback transcript uploads. |
+| `DO_NOT_TRACK=1` or `POSTHOG_ENABLED=false` | Disable CLI product analytics. |
 
 The insecure overrides transmit credentials or transcripts without transport
 encryption. Use them only for a trusted self-hosted network.
@@ -140,6 +154,14 @@ rather than being materialized without a safe bound.
 Keep secrets out of agent sessions, review your organization's data policies,
 and treat filtering as defense in depth. Report security issues through the
 private process in [SECURITY.md](SECURITY.md).
+
+Official CLI releases include PostHog capture configuration for a small set of
+usage events: first run, login attempts and results, and automatic-upload setup
+results. Events include CLI version and operating system; first run also includes
+the command name. Anonymous activity is linked to your account after login.
+These events exclude command arguments, connection codes, repository names,
+local paths, and session contents. Set `DO_NOT_TRACK=1` or
+`POSTHOG_ENABLED=false` to opt out. Source builds are unconfigured by default.
 
 ## Development
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -4,11 +4,22 @@ The canonical Opaline CLI package for Claude Code and OpenAI Codex session
 analytics.
 
 ```bash
-npm install --global @opalinehq/cli
-opaline login
-opaline upload
+npx @opalinehq/cli@latest
 opaline doctor
 ```
+
+Run this from any directory. The CLI scans local Claude Code and Codex sessions,
+shows repository and session counts, and lets you choose which repos to upload
+and keep syncing. Login opens only after selection. `pnpx @opalinehq/cli@latest`
+works too. A global install remains optional.
+
+Copying the command from the Opaline demo adds a hidden `--code` value. That
+one-time code pairs the terminal with your browser for live selection and upload
+status. It expires after ten minutes if unused. Approve login in the same browser
+where you copied the command; finishing setup opens your own Sessions page.
+
+Automatic uploads retain the bundled CLI under `~/.rudel/runtime` and use your
+Node executable, so hooks keep working after the temporary runner cache is gone.
 
 `opaline upload` groups discovered worktrees by repository, saves the selected
 repositories for automatic upload, and sends only sessions the server does not
@@ -26,3 +37,22 @@ Important: session transcripts are uploaded. Known-pattern secret filtering is
 best-effort and cannot guarantee that every sensitive value is removed.
 Capable servers use direct multipart object-storage uploads after filtering;
 older servers continue to use the legacy ingest endpoint.
+
+Official releases send a small set of usage events to PostHog: first run,
+login attempts and results, and automatic-upload setup results. These include
+the CLI version and operating system. The first-run event includes the command name.
+Setup results include the selected repository count, total local session count,
+and an anonymous list of session counts per repository, grouped by agent and
+destination workspace. Duplicate discoveries within a repository count once.
+These describe the selected local sessions, including previously uploaded ones,
+and do not measure successful uploads. `enable` measures the current repository;
+the `upload` picker measures the selected repositories. Counts are snapshots,
+not values to sum across repeated setup events or agents sharing a repository.
+An anonymous local identifier links activity to your Opaline account after login.
+Command arguments, connection codes, repository names, local paths, and session
+contents are not included in these product analytics events. `doctor` and hook
+invocations do not emit first-run events.
+
+Set `DO_NOT_TRACK=1` or `POSTHOG_ENABLED=false` to disable product analytics.
+Analytics failures do not prevent CLI commands from running. Source builds are
+unconfigured unless explicitly supplied with PostHog configuration.

--- a/apps/cli/build.ts
+++ b/apps/cli/build.ts
@@ -1,0 +1,18 @@
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { getBuildProductAnalyticsConfig } from "./src/lib/product-analytics-config.js";
+
+const analytics = getBuildProductAnalyticsConfig(process.env);
+const outdir = join(import.meta.dir, "dist");
+await rm(outdir, { recursive: true, force: true });
+
+for (const entrypoint of ["src/bin/cli.ts", "src/run-cli.ts"]) {
+	const result = await Bun.build({
+		entrypoints: [join(import.meta.dir, entrypoint)],
+		outdir,
+		target: "node",
+		define: { OPALINE_BUNDLED_ANALYTICS: JSON.stringify(analytics) },
+	});
+	if (!result.success)
+		throw new AggregateError(result.logs, "CLI build failed");
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -39,7 +39,7 @@
 	"scripts": {
 		"dev": "bun run src/bin/cli.ts",
 		"check-types": "tsc --noEmit",
-		"build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && bun build src/bin/cli.ts --outfile dist/cli.js --target node && bun build src/run-cli.ts --outfile dist/run-cli.js --target node",
+		"build": "bun run build.ts",
 		"prepack": "bun run build",
 		"test": "bun test",
 		"test:integration": "bun test ./src/__tests__/old-api-compat.test.ts ./src/__tests__/upload-destination.integration.test.ts",

--- a/apps/cli/src/__tests__/auto-upload-analytics.test.ts
+++ b/apps/cli/src/__tests__/auto-upload-analytics.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import {
+	PRODUCT_ANALYTICS_EVENTS,
+	parseProductAnalyticsEvent,
+} from "../contracts/product-analytics.js";
+import { summarizeAutoUploadRepositories } from "../lib/auto-upload-analytics.js";
+
+describe("automatic-upload repository analytics", () => {
+	test("folds worktrees into repositories and counts each local session once", () => {
+		const summaries = summarizeAutoUploadRepositories([
+			{
+				repositoryKey: "private/repo-a",
+				organizationId: "org-a",
+				source: "claude_code",
+				sessionIds: ["session-a", "session-b"],
+			},
+			{
+				repositoryKey: "private/repo-a",
+				organizationId: "org-a",
+				source: "claude_code",
+				sessionIds: ["session-b", "session-c"],
+			},
+			{
+				repositoryKey: "private/repo-b",
+				organizationId: "org-a",
+				source: "claude_code",
+				sessionIds: ["session-d"],
+			},
+		]);
+
+		expect(summaries).toEqual([
+			{
+				organization_id: "org-a",
+				agent_source: "claude_code",
+				repository_count: 2,
+				session_count: 4,
+				repository_session_counts: [3, 1],
+			},
+		]);
+		expect(JSON.stringify(summaries)).not.toContain("private/");
+		expect(JSON.stringify(summaries)).not.toContain("session-a");
+	});
+
+	test("keeps counts scoped to the event's organization and agent", () => {
+		const summaries = summarizeAutoUploadRepositories([
+			{
+				repositoryKey: "repo",
+				organizationId: "org-a",
+				source: "claude_code",
+				sessionIds: ["one", "two"],
+			},
+			{
+				repositoryKey: "repo",
+				organizationId: "org-a",
+				source: "codex",
+				sessionIds: ["one"],
+			},
+			{
+				repositoryKey: "repo",
+				organizationId: "org-b",
+				source: "claude_code",
+				sessionIds: ["one", "two", "three"],
+			},
+		]);
+
+		expect(summaries).toEqual([
+			{
+				organization_id: "org-a",
+				agent_source: "claude_code",
+				repository_count: 1,
+				session_count: 2,
+				repository_session_counts: [2],
+			},
+			{
+				organization_id: "org-a",
+				agent_source: "codex",
+				repository_count: 1,
+				session_count: 1,
+				repository_session_counts: [1],
+			},
+			{
+				organization_id: "org-b",
+				agent_source: "claude_code",
+				repository_count: 1,
+				session_count: 3,
+				repository_session_counts: [3],
+			},
+		]);
+	});
+
+	test("distinguishes an empty repository from no repositories selected", () => {
+		expect(summarizeAutoUploadRepositories([])).toEqual([]);
+		expect(
+			summarizeAutoUploadRepositories([
+				{
+					repositoryKey: "empty",
+					organizationId: undefined,
+					source: "codex",
+					sessionIds: [],
+				},
+			]),
+		).toEqual([
+			{
+				organization_id: undefined,
+				agent_source: "codex",
+				repository_count: 1,
+				session_count: 0,
+				repository_session_counts: [0],
+			},
+		]);
+	});
+
+	test("accepts count properties on existing events and rejects identifying extras", () => {
+		const payload = {
+			event_version: 1,
+			surface: "cli",
+			environment: "production",
+			cli_version: "0.5.3",
+			platform_os: "macos",
+			agent_source: "codex",
+			setup_command: "upload",
+			repository_count: 2,
+			session_count: 5,
+			repository_session_counts: [3, 2],
+		};
+		expect(
+			parseProductAnalyticsEvent(
+				PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLED,
+				payload,
+			),
+		).toEqual(payload);
+		const failure = {
+			...payload,
+			failure_stage: "hook_install",
+			failure_reason: "unknown",
+		};
+		expect(
+			parseProductAnalyticsEvent(
+				PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLE_FAILED,
+				failure,
+			),
+		).toEqual(failure);
+		expect(() =>
+			parseProductAnalyticsEvent(PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLED, {
+				...payload,
+				repository_names: ["private/repo"],
+			}),
+		).toThrow();
+		expect(() =>
+			parseProductAnalyticsEvent(PRODUCT_ANALYTICS_EVENTS.AUTO_UPLOAD_ENABLED, {
+				...payload,
+				repository_session_counts: [-1],
+			}),
+		).toThrow();
+	});
+});

--- a/apps/cli/src/__tests__/helpers/product-analytics-probe.ts
+++ b/apps/cli/src/__tests__/helpers/product-analytics-probe.ts
@@ -1,0 +1,31 @@
+import {
+	getCliDistinctId,
+	getNextCliLoginAttemptNumber,
+	identifyCliProductAnalyticsUser,
+	resetCliProductAnalyticsIdentity,
+	shutdownCliProductAnalytics,
+	trackCliFirstRun,
+} from "../../lib/product-analytics.js";
+
+switch (process.argv[2]) {
+	case "first-run":
+		trackCliFirstRun({ commandName: "help", isAuthenticated: false });
+		break;
+	case "login-attempt":
+		console.log(getNextCliLoginAttemptNumber());
+		break;
+	case "identity": {
+		const before = getCliDistinctId();
+		identifyCliProductAnalyticsUser("analytics-test-account-a");
+		identifyCliProductAnalyticsUser("analytics-test-account-b");
+		const switched = getCliDistinctId();
+		resetCliProductAnalyticsIdentity();
+		const loggedOut = getCliDistinctId();
+		console.log(JSON.stringify({ before, switched, loggedOut }));
+		break;
+	}
+	default:
+		throw new Error("Unknown analytics probe");
+}
+
+await shutdownCliProductAnalytics();

--- a/apps/cli/src/__tests__/persistent-hook-command.integration.test.ts
+++ b/apps/cli/src/__tests__/persistent-hook-command.integration.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, expect, test } from "bun:test";
+import assert from "node:assert/strict";
+import {
+	mkdir,
+	mkdtemp,
+	readFile,
+	realpath,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { parse } from "smol-toml";
+import { z } from "zod";
+
+const directories: string[] = [];
+afterAll(async () => {
+	await Promise.all(
+		directories.map((path) => rm(path, { recursive: true, force: true })),
+	);
+});
+
+test("published hooks survive runner-cache removal and preserve unrelated settings", async () => {
+	const home = await mkdtemp(join(tmpdir(), "opaline hook's home "));
+	directories.push(home);
+	const cache = join(home, "runner cache");
+	await mkdir(cache);
+	await mkdir(join(home, ".claude"));
+	await mkdir(join(home, ".codex"));
+	const settingsPath = join(home, ".claude", "settings.json");
+	const codexPath = join(home, ".codex", "config.toml");
+	await writeFile(
+		settingsPath,
+		JSON.stringify({
+			hooks: {
+				SessionEnd: [
+					{
+						matcher: "",
+						hooks: [
+							{ type: "command", command: "echo keep-me" },
+							{ type: "command", command: "opaline hooks claude session-end" },
+						],
+					},
+				],
+			},
+		}),
+	);
+	await writeFile(
+		codexPath,
+		'model = "gpt-5"\nnotify = ["rudel", "hooks", "codex", "turn-complete"]\n',
+	);
+	const installer = join(cache, "installer.ts");
+	await writeFile(
+		installer,
+		`import { addHook } from ${JSON.stringify(resolve(import.meta.dir, "../internal/agent-adapters/adapters/claude-code/settings.ts"))};
+import { installHook } from ${JSON.stringify(resolve(import.meta.dir, "../internal/agent-adapters/adapters/codex/config.ts"))};
+addHook(); installHook();`,
+	);
+	for (const entry of [resolve(import.meta.dir, "../bin/cli.ts"), installer]) {
+		await run(
+			[
+				process.execPath,
+				"build",
+				entry,
+				"--outdir",
+				cache,
+				"--target=node",
+				"--define=OPALINE_BUNDLED_ANALYTICS=null",
+			],
+			process.env,
+		);
+	}
+	await writeFile(join(cache, "package.json"), '{"type":"module"}');
+	const env = {
+		...process.env,
+		HOME: home,
+		USERPROFILE: home,
+		OPALINE_CONFIG_DIR: join(home, ".rudel"),
+		POSTHOG_ENABLED: "false",
+	};
+	const foundNode = Bun.which("node");
+	assert(foundNode);
+	const node = await realpath(foundNode);
+	await run([node, join(cache, "installer.js")], env);
+	const first = await readFile(settingsPath, "utf8");
+	await run([node, join(cache, "installer.js")], env);
+	expect(await readFile(settingsPath, "utf8")).toBe(first);
+	const settings = z
+		.object({
+			hooks: z.object({
+				SessionEnd: z.array(
+					z.object({ hooks: z.array(z.object({ command: z.string() })) }),
+				),
+			}),
+		})
+		.parse(JSON.parse(first));
+	const commands = settings.hooks.SessionEnd.flatMap((entry) =>
+		entry.hooks.map((hook) => hook.command),
+	);
+	expect(commands).toHaveLength(2);
+	expect(commands).toContain("echo keep-me");
+	const durablePath = join(home, ".rudel", "runtime", "cli.js");
+	const config = parse(await readFile(codexPath, "utf8"));
+	expect(config.model).toBe("gpt-5");
+	expect(config.notify).toEqual([
+		node,
+		durablePath,
+		"hooks",
+		"codex",
+		"turn-complete",
+	]);
+	await rm(cache, { recursive: true, force: true });
+	expect((await run([node, durablePath, "--version"], env)).trim()).toMatch(
+		/^\d+\.\d+\.\d+$/u,
+	);
+	const claude = commands.find((command) => command !== "echo keep-me");
+	assert(claude);
+	// Execute the exact shell command, including spaces and an apostrophe in HOME.
+	await run(["sh", "-c", claude], env, "{}");
+	const notify = z.array(z.string()).parse(config.notify);
+	await run([...notify, '{"type":"unrelated-event"}'], env);
+}, 30_000);
+
+async function run(command: string[], env: NodeJS.ProcessEnv, stdin = "") {
+	const child = Bun.spawn(command, {
+		env,
+		stdin: new Response(stdin),
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, code] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	expect(code, stderr).toBe(0);
+	return stdout;
+}

--- a/apps/cli/src/__tests__/product-analytics-config.test.ts
+++ b/apps/cli/src/__tests__/product-analytics-config.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeFailureReason } from "../lib/product-analytics.js";
+import {
+	getBuildProductAnalyticsConfig,
+	getProductAnalyticsConfig,
+	getProductAnalyticsEnvironment,
+} from "../lib/product-analytics-config.js";
+
+const bundled = {
+	key: "phc_test_public_token",
+	host: "https://us.i.posthog.com",
+};
+
+describe("published CLI analytics configuration", () => {
+	test("works without consumer environment variables", () => {
+		expect(getProductAnalyticsConfig({}, bundled)).toEqual(bundled);
+	});
+
+	test("source checkouts stay disabled without explicit configuration", () => {
+		expect(getProductAnalyticsConfig({}, null)).toBeNull();
+	});
+
+	test("either opt-out overrides bundled and explicit configuration", () => {
+		for (const optOut of [
+			{ POSTHOG_ENABLED: "false" },
+			{ POSTHOG_ENABLED: " FALSE " },
+			{ DO_NOT_TRACK: "1", POSTHOG_ENABLED: "true" },
+		]) {
+			expect(getProductAnalyticsConfig(optOut, bundled)).toBeNull();
+		}
+	});
+
+	test("test processes do not send to the bundled production project", () => {
+		expect(getProductAnalyticsConfig({ NODE_ENV: "test" }, bundled)).toBeNull();
+	});
+
+	test("explicit configuration works in source and test processes", () => {
+		expect(
+			getProductAnalyticsConfig(
+				{
+					NODE_ENV: "test",
+					POSTHOG_ENABLED: "true",
+					POSTHOG_KEY: bundled.key,
+					POSTHOG_HOST: bundled.host,
+				},
+				null,
+			),
+		).toEqual(bundled);
+	});
+
+	test("builds require both values and reject administrative keys", () => {
+		expect(getBuildProductAnalyticsConfig({})).toBeNull();
+		for (const environment of [
+			{ OPALINE_BUILD_POSTHOG_KEY: bundled.key },
+			{ OPALINE_BUILD_POSTHOG_HOST: bundled.host },
+			{
+				OPALINE_BUILD_POSTHOG_KEY: "phx_administrative_key",
+				OPALINE_BUILD_POSTHOG_HOST: bundled.host,
+			},
+			{
+				OPALINE_BUILD_POSTHOG_KEY: bundled.key,
+				OPALINE_BUILD_POSTHOG_HOST: "http://us.i.posthog.com",
+			},
+		]) {
+			expect(() => getBuildProductAnalyticsConfig(environment)).toThrow();
+		}
+	});
+
+	test("valid release inputs produce bundled public configuration", () => {
+		expect(
+			getBuildProductAnalyticsConfig({
+				OPALINE_BUILD_POSTHOG_KEY: bundled.key,
+				OPALINE_BUILD_POSTHOG_HOST: `${bundled.host}/`,
+			}),
+		).toEqual(bundled);
+	});
+});
+
+test("normal installations are labelled production without NODE_ENV", () => {
+	expect(getProductAnalyticsEnvironment({})).toBe("production");
+	expect(
+		getProductAnalyticsEnvironment({
+			OPALINE_API_BASE: "http://localhost:4010",
+		}),
+	).toBe("local");
+	expect(
+		getProductAnalyticsEnvironment({
+			RUDEL_API_BASE: "https://staging.opaline.so",
+		}),
+	).toBe("staging");
+	expect(getProductAnalyticsEnvironment({ OPALINE_API_BASE: "invalid" })).toBe(
+		"development",
+	);
+});
+
+test("failure reasons never expose arbitrary error messages", () => {
+	expect(
+		normalizeFailureReason(
+			new Error("secret repo /Users/alice/private token=123"),
+		),
+	).toBe("unknown");
+	expect(normalizeFailureReason(new Error("timed out"))).toBe("timeout");
+	expect(normalizeFailureReason(new TypeError("fetch failed"))).toBe(
+		"network_error",
+	);
+});

--- a/apps/cli/src/__tests__/product-analytics-state.test.ts
+++ b/apps/cli/src/__tests__/product-analytics-state.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, expect, test } from "bun:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+
+const root = await mkdtemp(join(tmpdir(), "opaline-analytics-tests-"));
+await writeFile(join(root, "package.json"), JSON.stringify({ type: "module" }));
+const result = await Bun.build({
+	entrypoints: [join(import.meta.dir, "helpers/product-analytics-probe.ts")],
+	outdir: root,
+	target: "node",
+});
+if (!result.success)
+	throw new AggregateError(result.logs, "Probe build failed");
+const probe = join(root, "product-analytics-probe.js");
+const unusedListener = createServer();
+await new Promise<void>((resolve) =>
+	unusedListener.listen(0, "127.0.0.1", resolve),
+);
+const address = unusedListener.address();
+assert(address && typeof address !== "string");
+const unavailableHost = `http://127.0.0.1:${address.port}`;
+await new Promise<void>((resolve, reject) =>
+	unusedListener.close((error) => (error ? reject(error) : resolve())),
+);
+const StateSchema = z.object({
+	cli_first_run_event_id: z.string().uuid().optional(),
+	cli_first_run_delivered: z.boolean().optional(),
+	cli_login_attempt_count: z.number().optional(),
+});
+
+afterAll(async () => {
+	await rm(root, { recursive: true, force: true });
+});
+
+test("disabled tracking neither consumes first run nor writes analytics state", async () => {
+	for (const optOut of [{ POSTHOG_ENABLED: "false" }, { DO_NOT_TRACK: "1" }]) {
+		const configDir = await mkdtemp(join(root, "disabled-"));
+		await runProbe("first-run", configDir, optOut);
+		expect(existsSync(join(configDir, "product-analytics.json"))).toBe(false);
+	}
+});
+
+test("failed delivery retries an old consumed first run with the same event UUID", async () => {
+	const configDir = await mkdtemp(join(root, "retry-"));
+	const statePath = join(configDir, "product-analytics.json");
+	await writeFile(statePath, JSON.stringify({ cli_first_run_tracked: true }));
+	await runProbe("first-run", configDir);
+	const first = StateSchema.parse(
+		JSON.parse(await readFile(statePath, "utf8")),
+	);
+	expect(first.cli_first_run_event_id).toBeDefined();
+	expect(first.cli_first_run_delivered).not.toBe(true);
+	await runProbe("first-run", configDir);
+	const retried = StateSchema.parse(
+		JSON.parse(await readFile(statePath, "utf8")),
+	);
+	expect(retried.cli_first_run_event_id).toBe(first.cli_first_run_event_id);
+	expect(retried.cli_first_run_delivered).not.toBe(true);
+});
+
+test("a confirmed first run is not sent again", async () => {
+	const configDir = await mkdtemp(join(root, "delivered-"));
+	const statePath = join(configDir, "product-analytics.json");
+	const original = JSON.stringify({ cli_first_run_delivered: true });
+	await writeFile(statePath, original);
+	await runProbe("first-run", configDir);
+	const state = StateSchema.parse(
+		JSON.parse(await readFile(statePath, "utf8")),
+	);
+	expect(state.cli_first_run_event_id).toBeUndefined();
+	expect(state.cli_first_run_delivered).toBe(true);
+});
+
+test("corrupt optional analytics state does not break login attempts", async () => {
+	const configDir = await mkdtemp(join(root, "corrupt-"));
+	await writeFile(
+		join(configDir, "product-analytics.json"),
+		JSON.stringify({ cli_login_attempt_count: "not a number" }),
+	);
+	expect((await runProbe("login-attempt", configDir)).trim()).toBe("1");
+});
+
+test("unwritable optional analytics state does not break the command", async () => {
+	const configDir = join(root, "file-instead-of-directory");
+	await writeFile(configDir, "cannot create a directory here");
+	await runProbe("first-run", configDir);
+	expect(await readFile(configDir, "utf8")).toBe(
+		"cannot create a directory here",
+	);
+});
+
+test("account switching and logout start separate anonymous identities", async () => {
+	const configDir = await mkdtemp(join(root, "identity-"));
+	const output = await runProbe("identity", configDir);
+	const ids = z
+		.object({ before: z.string(), switched: z.string(), loggedOut: z.string() })
+		.parse(JSON.parse(output));
+	expect(new Set(Object.values(ids)).size).toBe(3);
+});
+
+async function runProbe(
+	mode: string,
+	configDir: string,
+	environment: NodeJS.ProcessEnv = {},
+): Promise<string> {
+	const child = Bun.spawn(["node", probe, mode], {
+		env: {
+			...process.env,
+			OPALINE_CONFIG_DIR: configDir,
+			POSTHOG_ENABLED: "true",
+			POSTHOG_KEY: "phc_analytics_test",
+			// Exercise a real refused connection, with no mocked SDK or collector.
+			POSTHOG_HOST: unavailableHost,
+			DO_NOT_TRACK: "0",
+			...environment,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	expect(exitCode, stderr).toBe(0);
+	return stdout;
+}

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -1,5 +1,6 @@
 import { buildApplication, buildRouteMap } from "@stricli/core";
 import pkg from "../package.json" with { type: "json" };
+import { connectCommand } from "./commands/connect.js";
 import { devRouteMap } from "./commands/dev/index.js";
 import { disableCommand } from "./commands/disable.js";
 import { doctorCommand } from "./commands/doctor.js";
@@ -13,6 +14,7 @@ import { whoamiCommand } from "./commands/whoami.js";
 
 const routes = buildRouteMap({
 	routes: {
+		connect: connectCommand,
 		login: loginCommand,
 		logout: logoutCommand,
 		whoami: whoamiCommand,

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -1,0 +1,243 @@
+import { randomUUID } from "node:crypto";
+import * as p from "@clack/prompts";
+import { buildCommand } from "@stricli/core";
+import {
+	type CliConnectionRepository,
+	CliConnectionSecretSchema,
+} from "../contracts/cli-connection.js";
+import { sanitizeForTerminalDisplay } from "../contracts/index.js";
+import { allowsPlaintext, resolveApiBase } from "../lib/api-base.js";
+import { getDefaultApiBase } from "../lib/api-target.js";
+import {
+	loadAutoUploadConfig,
+	saveVisibleAutoUploadSelections,
+} from "../lib/auto-upload-config.js";
+import { connectBrowser } from "../lib/cli-connection.js";
+import { loadCredentials } from "../lib/credentials.js";
+import { getDefaultUploadOrganizationId } from "../lib/upload-organization.js";
+import { runLogin } from "./login.js";
+import {
+	discoverLocalUploadRepositories,
+	uploadSelectedRepositories,
+} from "./upload.js";
+
+async function runConnect(flags: {
+	code?: string;
+	apiBase: string;
+	allowInsecureApiBase: boolean;
+	noBrowser: boolean;
+}): Promise<undefined | Error> {
+	if (!process.stdin.isTTY)
+		return new Error(
+			"Run this command in an interactive terminal to select repositories.",
+		);
+	const resolved = resolveApiBase(
+		flags.apiBase,
+		allowsPlaintext(flags.allowInsecureApiBase),
+	);
+	if (!resolved.ok)
+		return new Error(
+			"Invalid API address. Use an HTTPS address or a local development server.",
+		);
+	if (flags.code && !CliConnectionSecretSchema.safeParse(flags.code).success)
+		return new Error(
+			"Invalid connection code. Copy the command again from the demo.",
+		);
+	let connection: Awaited<ReturnType<typeof connectBrowser>> | undefined;
+	let finished = false;
+	try {
+		p.intro("Opaline");
+		connection = flags.code
+			? await connectBrowser(resolved.url, flags.code)
+			: undefined;
+		const spin = p.spinner();
+		spin.start("Finding local Claude Code and Codex sessions...");
+		const discovery = await discoverLocalUploadRepositories();
+		spin.stop(
+			`Found ${discovery.repositories.length} repositories with local sessions`,
+		);
+		if (discovery.repositories.length === 0) {
+			connection?.stop();
+			await connection?.update({ kind: "status", state: "cancelled" });
+			finished = true;
+			p.outro(
+				"No local sessions found yet. Come back after using Claude Code or Codex.",
+			);
+			return;
+		}
+		const existing = loadAutoUploadConfig();
+		const selected = await p.multiselect({
+			message: "Choose repositories to upload and keep syncing",
+			options: discovery.repositories.map((repository) => ({
+				value: repository.key,
+				label: `${sanitizeForTerminalDisplay(repository.label)} (${repository.projects.reduce((sum, project) => sum + project.project.sessions.length, 0)} sessions)`,
+			})),
+			initialValues: discovery.repositories
+				.filter(
+					(repository) =>
+						existing === null ||
+						existing.repositories[repository.key] !== undefined,
+				)
+				.map((repository) => repository.key),
+			required: false,
+		});
+		if (p.isCancel(selected)) {
+			connection?.stop();
+			await connection?.update({ kind: "status", state: "cancelled" });
+			finished = true;
+			p.outro("No repositories selected. Nothing uploaded.");
+			return;
+		}
+		const selectedKeys = new Set(selected);
+		const manifest: CliConnectionRepository[] = discovery.repositories.map(
+			(repository) => ({
+				id: randomUUID(),
+				name:
+					sanitizeForTerminalDisplay(repository.label).slice(0, 160) ||
+					"Repository",
+				sessionCount: repository.projects.reduce(
+					(sum, project) => sum + project.project.sessions.length,
+					0,
+				),
+				enabled: selectedKeys.has(repository.key),
+				sources: Array.from(
+					new Set(repository.projects.map((project) => project.project.source)),
+				),
+			}),
+		);
+		await connection?.update({ kind: "selection", repositories: manifest });
+		if (selected.length === 0) {
+			saveVisibleAutoUploadSelections(
+				discovery.repositories.map((repository, index) => ({
+					key: repository.key,
+					label: repository.label,
+					sources: manifest[index]?.sources ?? [],
+				})),
+				selectedKeys,
+			);
+			connection?.stop();
+			await connection?.update({ kind: "status", state: "cancelled" });
+			finished = true;
+			p.outro(
+				"Automatic upload is off for all listed repositories. Nothing uploaded.",
+			);
+			return;
+		}
+		if (connection || !loadCredentials()) {
+			const activeConnection = connection;
+			const loginError = await runLogin(
+				{ ...flags, apiBase: resolved.url },
+				activeConnection
+					? {
+							id: activeConnection.id,
+							browserOrigin: activeConnection.browserOrigin,
+							registerDevice: (deviceCode) =>
+								activeConnection.update({ kind: "device", deviceCode }),
+						}
+					: undefined,
+			);
+			if (loginError) throw loginError;
+		}
+		const credentials = loadCredentials();
+		if (!credentials)
+			throw new Error("Login did not complete. Please try again.");
+		const organizations = credentials.organizations ?? [];
+		let organizationId = getDefaultUploadOrganizationId(
+			organizations,
+			credentials.user?.id,
+		);
+		if (!organizationId) {
+			if (organizations.length === 0)
+				throw new Error("No workspace found. Create one in Opaline first.");
+			const selectedOrganization = await p.select({
+				message: "Choose your upload workspace",
+				options: organizations.map((organization) => ({
+					value: organization.id,
+					label: organization.name,
+				})),
+			});
+			if (p.isCancel(selectedOrganization))
+				throw new Error("Workspace selection cancelled.");
+			organizationId = selectedOrganization;
+		}
+		await connection?.update({ kind: "bind", organizationId }, credentials);
+		const result = await uploadSelectedRepositories(
+			{
+				discovery,
+				selectedKeys,
+				onUploadStarted: async () =>
+					connection?.update({ kind: "status", state: "uploading" }),
+				onUploadFinished: async ({
+					uploaded,
+					skipped,
+					failed,
+					hookFailures,
+				}) => {
+					connection?.stop();
+					await connection?.update({
+						kind: "status",
+						state: failed > 0 || hookFailures > 0 ? "failed" : "completed",
+						totals: { uploaded, skipped, failed },
+						failureReason:
+							failed > 0
+								? "upload_failed"
+								: hookFailures > 0
+									? "hook_setup_failed"
+									: null,
+					});
+					finished = true;
+				},
+			},
+			credentials,
+			organizationId,
+			flags.allowInsecureApiBase,
+		);
+		if (result) throw result;
+	} catch (error) {
+		connection?.stop();
+		if (!finished)
+			await connection
+				?.update({
+					kind: "status",
+					state: "failed",
+					failureReason: "connection_failed",
+				})
+				.catch(() => {});
+		return error instanceof Error
+			? error
+			: new Error("Setup failed. Please try again.");
+	} finally {
+		connection?.stop();
+	}
+}
+
+export const connectCommand = buildCommand({
+	loader: async () => ({ default: runConnect }),
+	parameters: {
+		flags: {
+			code: {
+				kind: "parsed",
+				parse: String,
+				optional: true,
+				brief: "One-time code copied from the Opaline demo",
+			},
+			apiBase: {
+				kind: "parsed",
+				parse: String,
+				default: getDefaultApiBase(),
+				brief: "API server base URL",
+			},
+			allowInsecureApiBase: {
+				kind: "boolean",
+				default: false,
+				brief: "Allow a plaintext self-hosted server",
+			},
+			noBrowser: {
+				kind: "boolean",
+				default: false,
+				brief: "Print the login link without opening a browser",
+			},
+		},
+	},
+	docs: { brief: "Choose local repositories and connect them to Opaline" },
+});

--- a/apps/cli/src/commands/enable.ts
+++ b/apps/cli/src/commands/enable.ts
@@ -9,6 +9,11 @@ import { describeSavedCredentialsApiBaseRisk } from "../lib/api-base.js";
 import { createApiClient } from "../lib/api-client.js";
 import { PRODUCTION_API_BASE } from "../lib/api-target.js";
 import { verifyAuth } from "../lib/auth.js";
+import {
+	type AutoUploadHookResult,
+	captureAutoUploadSetupResult,
+	summarizeAutoUploadRepositories,
+} from "../lib/auto-upload-analytics.js";
 import { enableAutoUploadRepository } from "../lib/auto-upload-config.js";
 import type { BatchUploadItem } from "../lib/batch-upload.js";
 import { renderBatchSummary, runBatchUpload } from "../lib/batch-upload-ui.js";
@@ -45,6 +50,7 @@ async function runEnable(): Promise<undefined | Error> {
 			surface: "cli",
 			disablePersonProfile: shouldDisableCliPersonProfile(options.userId),
 			payload: {
+				setup_command: "enable",
 				agent_source: options.agentSource ?? "unknown",
 				failure_stage: options.failureStage,
 				failure_reason: normalizeFailureReason(options.error),
@@ -148,6 +154,7 @@ async function runEnable(): Promise<undefined | Error> {
 	const adapters = getAvailableAdapters();
 	let adaptersToEnable: AgentAdapter[];
 	let hookInstallFailures = 0;
+	const hookResults = new Map<Source, AutoUploadHookResult>();
 
 	if (adapters.length > 1) {
 		const agentOptions = adapters.map((a) => ({
@@ -185,43 +192,30 @@ async function runEnable(): Promise<undefined | Error> {
 	for (const adapter of adaptersToEnable) {
 		const isAlreadyEnabled = adapter.isHookInstalled();
 
-		if (isAlreadyEnabled) {
-			p.log.info(
-				`${adapter.name}: Auto-upload hook is already enabled. Organization updated.`,
+		try {
+			adapter.installHook();
+			p.log.success(
+				isAlreadyEnabled
+					? `${adapter.name}: Auto-upload hook updated. Organization updated.`
+					: `${adapter.name}: Auto-upload hook enabled in ${adapter.getHookConfigPath()}`,
 			);
-		} else {
-			try {
-				adapter.installHook();
-				p.log.success(
-					`${adapter.name}: Auto-upload hook enabled in ${adapter.getHookConfigPath()}`,
-				);
-			} catch (error) {
-				hookInstallFailures++;
-				captureEnableFailure({
-					agentSource: adapter.source,
-					failureStage: "hook_install",
-					error,
-					organizationId: selectedOrgId,
-					userId: auth.user.id,
-				});
-				p.log.error(
-					`${adapter.name}: failed to enable auto-upload hook (${error instanceof Error ? error.message : String(error)})`,
-				);
-				continue;
-			}
+		} catch (error) {
+			hookInstallFailures++;
+			hookResults.set(adapter.source, {
+				source: adapter.source,
+				status: "failed",
+				error,
+			});
+			p.log.error(
+				`${adapter.name}: failed to enable auto-upload hook (${error instanceof Error ? error.message : String(error)})`,
+			);
+			continue;
 		}
 
-		captureCliProductAnalyticsEvent({
-			distinctId: auth.user.id,
-			event: CliProductAnalyticsEvents.AUTO_UPLOAD_ENABLED,
-			surface: "cli",
-			payload: {
-				organization_id: selectedOrgId,
-				user_id: auth.user.id,
-				agent_source: adapter.source,
-				is_already_enabled: isAlreadyEnabled || undefined,
-				...getBaseCliEventPayload(),
-			},
+		hookResults.set(adapter.source, {
+			source: adapter.source,
+			status: "enabled",
+			alreadyInstalled: isAlreadyEnabled,
 		});
 	}
 
@@ -230,8 +224,32 @@ async function runEnable(): Promise<undefined | Error> {
 	const allowPlaintextEndpoint = allowsInsecureEndpointFromEnv();
 	let totalFailed = 0;
 
-	for (const adapter of adaptersToEnable) {
-		const sessions = await adapter.findProjectSessions(cwd);
+	const discovered = await Promise.all(
+		adaptersToEnable.map(async (adapter) => ({
+			adapter,
+			sessions: await adapter.findProjectSessions(cwd),
+		})),
+	);
+	for (const { adapter, sessions } of discovered) {
+		const result = hookResults.get(adapter.source);
+		if (result) {
+			captureAutoUploadSetupResult({
+				result,
+				summaries: summarizeAutoUploadRepositories([
+					{
+						repositoryKey: repository.repoKey,
+						organizationId: selectedOrgId,
+						source: adapter.source,
+						sessionIds: sessions.map((session) => session.sessionId),
+					},
+				]),
+				userId: auth.user.id,
+				command: "enable",
+			});
+		}
+	}
+
+	for (const { adapter, sessions } of discovered) {
 		if (sessions.length === 0) continue;
 
 		const shouldUpload = await p.confirm({

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -26,6 +26,7 @@ import {
 	getBaseCliEventPayload,
 	getCliDistinctId,
 	getNextCliLoginAttemptNumber,
+	identifyCliProductAnalyticsUser,
 	normalizeFailureReason,
 	shouldDisableCliPersonProfile,
 } from "../lib/product-analytics.js";
@@ -190,13 +191,20 @@ async function createIngestApiKey(
 	return parsed.data;
 }
 
-async function runLogin(flags: {
-	apiBase: string;
-	allowInsecureApiBase: boolean;
-	noBrowser: boolean;
-}): Promise<undefined | Error> {
-	const openedBrowser = !flags.noBrowser;
-	const attemptNumber = getNextCliLoginAttemptNumber();
+export async function runLogin(
+	flags: {
+		apiBase: string;
+		allowInsecureApiBase: boolean;
+		noBrowser: boolean;
+	},
+	connection?: {
+		readonly id: string;
+		readonly browserOrigin: string;
+		readonly registerDevice: (deviceCode: string) => Promise<unknown>;
+	},
+): Promise<undefined | Error> {
+	let openedBrowser = false;
+	let attemptNumber = 1;
 	const captureLoginFailure = (
 		failureStage: ProductAnalyticsLoginFailureStage,
 		error: unknown,
@@ -220,11 +228,24 @@ async function runLogin(flags: {
 	p.intro("opaline login");
 
 	const existing = loadCredentials();
-	if (existing) {
+	if (existing && !connection) {
 		p.log.warn("Already logged in.");
 		p.outro("Run `opaline logout` first to switch accounts.");
 		return;
 	}
+	attemptNumber = getNextCliLoginAttemptNumber();
+	captureCliProductAnalyticsEvent({
+		distinctId: getCliDistinctId(),
+		event: CliProductAnalyticsEvents.CLI_LOGIN_STARTED,
+		surface: "cli",
+		disablePersonProfile: true,
+		payload: {
+			auth_flow: "device_authorization",
+			opened_browser: false,
+			attempt_number: attemptNumber,
+			...getBaseCliEventPayload(),
+		},
+	});
 
 	// Resolved once and threaded through both URL checks below, so a plaintext
 	// self-hosted deployment cannot pass one gate and fail the other.
@@ -252,7 +273,12 @@ async function runLogin(flags: {
 	// The verification URL is server-controlled. Validate it before it reaches the
 	// terminal or a platform opener, and use the reserialized form so control
 	// characters stay percent-encoded (RUD-203).
-	const rawVerifyUrl = buildVerificationUrl(deviceCode);
+	const rawVerifyUrl = connection
+		? new URL(
+				`/device?user_code=${encodeURIComponent(deviceCode.user_code)}`,
+				connection.browserOrigin,
+			).toString()
+		: buildVerificationUrl(deviceCode);
 	const verifyUrlResult = parseSafeBrowserUrl(rawVerifyUrl, { allowPlaintext });
 	if (!verifyUrlResult.ok) {
 		const error = new Error(
@@ -261,20 +287,13 @@ async function runLogin(flags: {
 		captureLoginFailure("verification_url_rejected", error);
 		return error;
 	}
-	const verifyUrl = verifyUrlResult.url;
-
-	captureCliProductAnalyticsEvent({
-		distinctId: getCliDistinctId(),
-		event: CliProductAnalyticsEvents.CLI_LOGIN_STARTED,
-		surface: "cli",
-		disablePersonProfile: shouldDisableCliPersonProfile(),
-		payload: {
-			auth_flow: "device_authorization",
-			opened_browser: openedBrowser,
-			attempt_number: attemptNumber,
-			...getBaseCliEventPayload(),
-		},
-	});
+	let verifyUrl = verifyUrlResult.url;
+	if (connection) {
+		await connection.registerDevice(deviceCode.device_code);
+		const connectedUrl = new URL(verifyUrl);
+		connectedUrl.searchParams.set("connect", connection.id);
+		verifyUrl = connectedUrl.toString();
+	}
 
 	p.log.info(`If the browser doesn't open, visit:\n${verifyUrl}`);
 	// `user_code` is server-controlled and printed raw to the terminal, so it is
@@ -283,6 +302,7 @@ async function runLogin(flags: {
 
 	if (!flags.noBrowser) {
 		openUrl(verifyUrl);
+		openedBrowser = true;
 	}
 
 	const spin = p.spinner();
@@ -353,6 +373,7 @@ async function runLogin(flags: {
 		return new Error("Login failed: unable to persist credentials");
 	}
 
+	identifyCliProductAnalyticsUser(user.id);
 	captureCliProductAnalyticsEvent({
 		distinctId: user.id,
 		event: CliProductAnalyticsEvents.CLI_LOGIN_APPROVED,

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -3,6 +3,7 @@ import { buildCommand } from "@stricli/core";
 import { describeLogoutApiBaseRisk } from "../lib/api-base.js";
 import { createApiClient } from "../lib/api-client.js";
 import { clearCredentials, loadCredentials } from "../lib/credentials.js";
+import { resetCliProductAnalyticsIdentity } from "../lib/product-analytics.js";
 
 async function runLogout(flags: {
 	localOnly: boolean;
@@ -32,6 +33,7 @@ async function runLogout(flags: {
 	}
 
 	clearCredentials();
+	resetCliProductAnalyticsIdentity();
 	p.log.success(
 		flags.localOnly
 			? "Logged out locally. Server token was not revoked."

--- a/apps/cli/src/commands/upload.ts
+++ b/apps/cli/src/commands/upload.ts
@@ -18,6 +18,11 @@ import {
 	type SessionFile,
 } from "../internal/agent-adapters/index.js";
 import {
+	type AutoUploadHookResult,
+	captureAutoUploadSetupResult,
+	summarizeAutoUploadRepositories,
+} from "../lib/auto-upload-analytics.js";
+import {
 	type AutoUploadConfig,
 	getRequiredAutoUploadSources,
 	loadAutoUploadConfig,
@@ -98,19 +103,77 @@ interface PreparedUploadTarget {
 	readonly target: UploadProjectTarget;
 }
 
+interface GuidedUploadOptions {
+	readonly discovery: Awaited<
+		ReturnType<typeof discoverLocalUploadRepositories>
+	>;
+	readonly selectedKeys: ReadonlySet<string>;
+	readonly onUploadStarted: () => Promise<unknown>;
+	readonly onUploadFinished: (result: {
+		uploaded: number;
+		skipped: number;
+		failed: number;
+		hookFailures: number;
+	}) => Promise<unknown>;
+}
+
+export async function discoverLocalUploadRepositories() {
+	const scan = await scanAndGroupProjects({ persistRemoteCache: false });
+	const prepared = await pMap(
+		scan.projects,
+		(project) => prepareUploadTarget(project, undefined),
+		{ concurrency: 10 },
+	);
+	const repositories = groupUploadProjectsByRepository(
+		prepared.map(({ target, metadata }) => ({
+			...target,
+			...metadata,
+			newSessions: target.project.sessions,
+		})),
+	);
+	return { scan, prepared, repositories };
+}
+
+export async function uploadSelectedRepositories(
+	options: GuidedUploadOptions,
+	credentials: Credentials,
+	organizationId: string,
+	allowInsecureEndpoint: boolean,
+) {
+	return runInteractiveUpload(
+		{
+			endpoint: `${credentials.apiBaseUrl.replace(/\/+$/u, "")}/rpc`,
+			org: organizationId,
+			allowInsecureEndpoint,
+			classify: false,
+			dryRun: false,
+			retry: false,
+			yes: true,
+			concurrency: 3,
+			forceReplace: false,
+		},
+		allowsInsecureEndpoint(allowInsecureEndpoint),
+		credentials,
+		options,
+	);
+}
+
 async function runInteractiveUpload(
 	flags: ResolvedUploadFlags,
 	allowPlaintextEndpoint: boolean,
 	credentials: Credentials | null,
+	guided?: GuidedUploadOptions,
 ): Promise<undefined | Error> {
 	p.intro("opaline upload");
 
 	const spin = p.spinner();
 	spin.start("Scanning projects...");
 
-	const { projects: allProjects, groups } = await scanAndGroupProjects({
-		persistRemoteCache: !flags.dryRun,
-	});
+	const { projects: allProjects, groups } =
+		guided?.discovery.scan ??
+		(await scanAndGroupProjects({
+			persistRemoteCache: !flags.dryRun,
+		}));
 
 	if (allProjects.length === 0) {
 		spin.stop("No local sessions found");
@@ -119,11 +182,16 @@ async function runInteractiveUpload(
 		return;
 	}
 
-	const preparedTargets = await pMap(
-		allProjects,
-		(project) => prepareUploadTarget(project, flags.org),
-		{ concurrency: 10 },
-	);
+	const preparedTargets = guided
+		? guided.discovery.prepared.map((prepared) => ({
+				...prepared,
+				target: { ...prepared.target, organizationId: flags.org },
+			}))
+		: await pMap(
+				allProjects,
+				(project) => prepareUploadTarget(project, flags.org),
+				{ concurrency: 10 },
+			);
 	const organizations = credentials?.organizations ?? [];
 	let defaultOrganizationId = getDefaultUploadOrganizationId(
 		organizations,
@@ -256,12 +324,14 @@ async function runInteractiveUpload(
 		if (autoUploadSelected) preSelected.push(repository.key);
 	}
 
-	const selected = await p.multiselect({
-		message: "Choose repositories for automatic upload",
-		options,
-		initialValues: preSelected,
-		required: false,
-	});
+	const selected = guided
+		? Array.from(guided.selectedKeys)
+		: await p.multiselect({
+				message: "Choose repositories for automatic upload",
+				options,
+				initialValues: preSelected,
+				required: false,
+			});
 
 	if (p.isCancel(selected)) {
 		p.cancel("Upload cancelled.");
@@ -328,12 +398,35 @@ async function runInteractiveUpload(
 		orderedRepositories.map(toAutoUploadRepositorySelection),
 		selectedRepoKeys,
 	);
-	const hookFailures = reconcileAutoUploadHooks(savedAutoUploadConfig);
+	const repositorySummaries = summarizeAutoUploadRepositories(
+		selectedRepositories.flatMap((repository) =>
+			repository.projects.map((project) => ({
+				repositoryKey: repository.key,
+				organizationId: project.organizationId,
+				source: project.project.source,
+				sessionIds: project.project.sessions.map(
+					(session) => session.sessionId,
+				),
+			})),
+		),
+	);
+	const hookFailures = reconcileAutoUploadHooks(
+		savedAutoUploadConfig,
+		(result) => {
+			captureAutoUploadSetupResult({
+				result,
+				summaries: repositorySummaries,
+				userId: credentials.user?.id,
+				command: "upload",
+			});
+		},
+	);
 
 	const uploadingRepositoryCount = selectedRepositories.filter(
 		(repository) =>
 			getRepositorySessionsToUpload(repository, flags.forceReplace).length > 0,
 	).length;
+	await guided?.onUploadStarted();
 	if (totalSessions > 0) {
 		p.log.info(
 			`Uploading ${totalSessions} session(s) from ${uploadingRepositoryCount} ${repositoryCountHint(uploadingRepositoryCount)}`,
@@ -345,6 +438,12 @@ async function runInteractiveUpload(
 	}
 	logSkippedSessions(skippedUploadedSessions, skippedDuplicateSessions);
 	if (totalSessions === 0) {
+		await guided?.onUploadFinished({
+			uploaded: 0,
+			skipped: skippedUploadedSessions + skippedDuplicateSessions,
+			failed: 0,
+			hookFailures,
+		});
 		p.outro("Automatic upload settings saved.");
 		if (hookFailures > 0) {
 			return new Error(`${hookFailures} auto-upload hook change(s) failed.`);
@@ -434,6 +533,13 @@ async function runInteractiveUpload(
 		},
 	});
 
+	await guided?.onUploadFinished({
+		uploaded: summary.succeeded,
+		skipped:
+			skippedUploadedSessions + skippedDuplicateSessions + summary.skipped,
+		failed: summary.failed,
+		hookFailures,
+	});
 	renderBatchSummary(summary, { showRetryHint: summary.failed > 0 });
 
 	p.outro("Done!");
@@ -609,23 +715,33 @@ function logAutoUploadSelectionPreview(
 	}
 }
 
-function reconcileAutoUploadHooks(config: AutoUploadConfig): number {
+function reconcileAutoUploadHooks(
+	config: AutoUploadConfig,
+	onResult: (result: AutoUploadHookResult) => void,
+): number {
 	const requiredSources = getRequiredAutoUploadSources(config);
 	let failures = 0;
 	for (const adapter of getAllAdapters()) {
 		const required = requiredSources.has(adapter.source);
 		const installed = adapter.isHookInstalled();
-		if (required === installed) continue;
+		if (!required && !installed) continue;
 		try {
 			if (required) {
 				adapter.installHook();
 				p.log.success(`${adapter.name}: automatic upload hook enabled`);
+				onResult({
+					source: adapter.source,
+					status: "enabled",
+					alreadyInstalled: installed,
+				});
 			} else {
 				adapter.removeHook();
 				p.log.success(`${adapter.name}: automatic upload hook removed`);
 			}
 		} catch (error) {
 			failures++;
+			if (required)
+				onResult({ source: adapter.source, status: "failed", error });
 			p.log.error(
 				`${adapter.name}: could not ${required ? "enable" : "remove"} automatic upload hook (${error instanceof Error ? error.message : String(error)})`,
 			);

--- a/apps/cli/src/contracts/cli-connection.ts
+++ b/apps/cli/src/contracts/cli-connection.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+
+export const CLI_CONNECTION_PATH = "/api/cli/connections";
+export const CLI_CONNECTION_CODE_TTL_MS = 10 * 60_000;
+export const CLI_CONNECTION_TTL_MS = 2 * 60 * 60_000;
+export const CliConnectionSecretSchema = z
+	.string()
+	.regex(/^[A-Za-z0-9_-]{43}$/u);
+export const CliConnectionIdSchema = z.string().uuid();
+const count = z.number().int().min(0).max(10_000_000);
+export const CliConnectionRepositorySchema = z
+	.object({
+		id: z.string().uuid(),
+		name: z
+			.string()
+			.trim()
+			.min(1)
+			.max(160)
+			.refine(
+				(name) =>
+					Array.from(name).every(
+						(character) =>
+							character.charCodeAt(0) > 31 && character.charCodeAt(0) !== 127,
+					),
+				"Control characters are not allowed",
+			),
+		sessionCount: count,
+		enabled: z.boolean(),
+		sources: z
+			.array(z.enum(["claude_code", "codex"]))
+			.min(1)
+			.max(2),
+	})
+	.strict();
+export const CliConnectionRepositoriesSchema = z
+	.array(CliConnectionRepositorySchema)
+	.max(1_000)
+	.refine(
+		(repositories) =>
+			new Set(repositories.map(({ id }) => id)).size === repositories.length,
+		"Repository IDs must be unique",
+	);
+export const CliConnectionTotalsSchema = z
+	.object({
+		uploaded: count,
+		skipped: count,
+		failed: count,
+	})
+	.strict();
+export const CliConnectionStateSchema = z.enum([
+	"waiting",
+	"scanning",
+	"awaiting_login",
+	"ready",
+	"uploading",
+	"completed",
+	"failed",
+	"cancelled",
+	"expired",
+]);
+export const CliConnectionSnapshotSchema = z
+	.object({
+		id: CliConnectionIdSchema,
+		browserOrigin: z.string().url(),
+		state: CliConnectionStateSchema,
+		revision: z.number().int().nonnegative(),
+		createdAt: z.string().datetime(),
+		expiresAt: z.string().datetime(),
+		lastSeenAt: z.string().datetime(),
+		repositories: CliConnectionRepositoriesSchema,
+		organizationId: z.string().min(1).nullable(),
+		totals: CliConnectionTotalsSchema.nullable(),
+		failureReason: z
+			.enum([
+				"upload_failed",
+				"hook_setup_failed",
+				"connection_failed",
+				"login_failed",
+			])
+			.nullable(),
+	})
+	.strict();
+export const CliConnectionCreateResponseSchema = z
+	.object({
+		connection: CliConnectionSnapshotSchema,
+		code: CliConnectionSecretSchema,
+		codeExpiresAt: z.string().datetime(),
+	})
+	.strict();
+export const CliConnectionRedeemSchema = z
+	.object({
+		code: CliConnectionSecretSchema,
+		writerToken: CliConnectionSecretSchema,
+	})
+	.strict();
+export const CliConnectionUpdateSchema = z
+	.object({
+		writerToken: CliConnectionSecretSchema,
+		sequence: z.number().int().positive(),
+		update: z.discriminatedUnion("kind", [
+			z
+				.object({
+					kind: z.literal("selection"),
+					repositories: CliConnectionRepositoriesSchema,
+				})
+				.strict(),
+			z
+				.object({
+					kind: z.literal("device"),
+					deviceCode: z.string().min(1).max(256),
+				})
+				.strict(),
+			z
+				.object({
+					kind: z.literal("bind"),
+					organizationId: z.string().min(1).max(128),
+				})
+				.strict(),
+			z.object({ kind: z.literal("heartbeat") }).strict(),
+			z
+				.object({
+					kind: z.literal("status"),
+					state: z.enum(["uploading", "completed", "failed", "cancelled"]),
+					totals: CliConnectionTotalsSchema.optional(),
+					failureReason:
+						CliConnectionSnapshotSchema.shape.failureReason.optional(),
+				})
+				.strict(),
+		]),
+	})
+	.strict();
+export const CliConnectionAuthorizeSchema = z
+	.object({ userCode: z.string().min(1).max(256) })
+	.strict();
+export type CliConnectionSnapshot = z.infer<typeof CliConnectionSnapshotSchema>;
+export type CliConnectionRepository = z.infer<
+	typeof CliConnectionRepositorySchema
+>;
+export type CliConnectionUpdate = z.infer<typeof CliConnectionUpdateSchema>;
+export function isCliConnectionTerminal(
+	state: CliConnectionSnapshot["state"],
+): boolean {
+	return ["completed", "failed", "cancelled", "expired"].includes(state);
+}

--- a/apps/cli/src/contracts/product-analytics.ts
+++ b/apps/cli/src/contracts/product-analytics.ts
@@ -23,6 +23,7 @@ export const ProductAnalyticsPlatformOsSchema = z.enum([
 ]);
 export const ProductAnalyticsAuthFlowSchema = z.literal("device_authorization");
 export const ProductAnalyticsCliCommandNameSchema = z.enum([
+	"connect",
 	"login",
 	"logout",
 	"whoami",
@@ -71,6 +72,18 @@ const RequiredCommonSchema = z.object({
 });
 const idSchema = z.string().min(1);
 const nonEmptyStringSchema = z.string().min(1);
+const repositoryCountsSchema = z.object({
+	repository_count: z.number().int().nonnegative(),
+	session_count: z.number().int().nonnegative(),
+	repository_session_counts: z.array(z.number().int().nonnegative()),
+});
+export type ProductAnalyticsRepositoryCounts = z.infer<
+	typeof repositoryCountsSchema
+>;
+const autoUploadSetupProperties = {
+	...repositoryCountsSchema.partial().shape,
+	setup_command: z.enum(["enable", "upload"]).optional(),
+};
 
 export const PRODUCT_ANALYTICS_EVENTS = {
 	CLI_FIRST_RUN: "CLI First Run",
@@ -123,9 +136,10 @@ const CliLoginFailedEventSchema = RequiredCommonSchema.extend({
 }).strict();
 
 const AutoUploadEnabledEventSchema = RequiredCommonSchema.extend({
+	...autoUploadSetupProperties,
 	surface: z.literal("cli"),
-	organization_id: idSchema,
-	user_id: idSchema,
+	organization_id: idSchema.optional(),
+	user_id: idSchema.optional(),
 	agent_source: SourceSchema,
 	cli_version: nonEmptyStringSchema,
 	platform_os: ProductAnalyticsPlatformOsSchema,
@@ -133,6 +147,7 @@ const AutoUploadEnabledEventSchema = RequiredCommonSchema.extend({
 }).strict();
 
 const AutoUploadEnableFailedEventSchema = RequiredCommonSchema.extend({
+	...autoUploadSetupProperties,
 	surface: z.literal("cli"),
 	agent_source: z.union([SourceSchema, z.literal("unknown")]),
 	failure_stage: ProductAnalyticsEnableFailureStageSchema,

--- a/apps/cli/src/internal/agent-adapters/adapters/claude-code/settings.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/claude-code/settings.ts
@@ -1,6 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import {
+	getPersistentCliPath,
+	getPersistentHookCommand,
+	quoteHookArgument,
+} from "../../persistent-hook-command.js";
 
 const HOOK_COMMAND = "opaline hooks claude session-end";
 const LEGACY_HOOK_COMMAND = "rudel hooks claude session-end";
@@ -51,6 +56,11 @@ export function isHookEnabled(): boolean {
 }
 
 export function addHook(): void {
+	const argv = getPersistentHookCommand(["hooks", "claude", "session-end"]);
+	const command =
+		argv[0] === "opaline"
+			? HOOK_COMMAND
+			: `${argv.slice(0, 2).map(quoteHookArgument).join(" ")} hooks claude session-end`;
 	const settings = readClaudeSettings();
 	if (!settings.hooks) {
 		settings.hooks = {};
@@ -61,9 +71,9 @@ export function addHook(): void {
 
 	for (const entry of settings.hooks.SessionEnd) {
 		for (const hook of entry.hooks ?? []) {
-			if (hook.command === HOOK_COMMAND) return;
-			if (hook.command === LEGACY_HOOK_COMMAND) {
-				hook.command = HOOK_COMMAND;
+			if (hook.command === command) return;
+			if (isOpalineHookCommand(hook.command)) {
+				hook.command = command;
 				writeClaudeSettings(settings);
 				return;
 			}
@@ -72,7 +82,7 @@ export function addHook(): void {
 
 	settings.hooks.SessionEnd.push({
 		matcher: "",
-		hooks: [{ type: "command", command: HOOK_COMMAND, async: true }],
+		hooks: [{ type: "command", command, async: true }],
 	});
 
 	writeClaudeSettings(settings);
@@ -102,5 +112,11 @@ export function removeHook(): void {
 }
 
 function isOpalineHookCommand(command: string): boolean {
-	return command === HOOK_COMMAND || command === LEGACY_HOOK_COMMAND;
+	return (
+		command === HOOK_COMMAND ||
+		command === LEGACY_HOOK_COMMAND ||
+		command.endsWith(
+			` ${quoteHookArgument(getPersistentCliPath())} hooks claude session-end`,
+		)
+	);
 }

--- a/apps/cli/src/internal/agent-adapters/adapters/codex/config.ts
+++ b/apps/cli/src/internal/agent-adapters/adapters/codex/config.ts
@@ -2,6 +2,10 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse as parseTOML, stringify as stringifyTOML } from "smol-toml";
+import {
+	getPersistentHookCommand,
+	isPersistentHookCommand,
+} from "../../persistent-hook-command.js";
 
 export const CONFIG_PATH = join(homedir(), ".codex", "config.toml");
 const HOOK_COMMAND = ["opaline", "hooks", "codex", "turn-complete"] as const;
@@ -42,7 +46,8 @@ function commandsMatch(
 function isOpalineHookCommand(command: readonly string[]): boolean {
 	return (
 		commandsMatch(command, HOOK_COMMAND) ||
-		commandsMatch(command, LEGACY_HOOK_COMMAND)
+		commandsMatch(command, LEGACY_HOOK_COMMAND) ||
+		isPersistentHookCommand(command, ["hooks", "codex", "turn-complete"])
 	);
 }
 
@@ -55,9 +60,10 @@ export function installHook(configPath: string = CONFIG_PATH): void {
 		);
 	}
 	const current = notify ?? [];
-	if (commandsMatch(current, HOOK_COMMAND)) return;
-	if (commandsMatch(current, LEGACY_HOOK_COMMAND)) {
-		config.notify = [...HOOK_COMMAND];
+	const command = getPersistentHookCommand(["hooks", "codex", "turn-complete"]);
+	if (commandsMatch(current, command)) return;
+	if (isOpalineHookCommand(current)) {
+		config.notify = command;
 		writeConfig(configPath, config);
 		return;
 	}
@@ -69,7 +75,7 @@ export function installHook(configPath: string = CONFIG_PATH): void {
 			: current;
 
 	if (withoutLegacy.length === 0) {
-		config.notify = [...HOOK_COMMAND];
+		config.notify = command;
 		writeConfig(configPath, config);
 		return;
 	}

--- a/apps/cli/src/internal/agent-adapters/persistent-hook-command.ts
+++ b/apps/cli/src/internal/agent-adapters/persistent-hook-command.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from "node:crypto";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getConfigDir } from "../../lib/local-state.js";
+
+export function getPersistentHookCommand(args: readonly string[]): string[] {
+	const currentFile = fileURLToPath(import.meta.url);
+	// Development TypeScript runs keep the ordinary command. Published bundles
+	// are self-contained Node files and can be retained outside the runner cache.
+	if (extname(currentFile) !== ".js") return ["opaline", ...args];
+	const source = join(dirname(currentFile), "cli.js");
+	if (!existsSync(source))
+		throw new Error("Could not find the CLI bundle for automatic uploads.");
+	const target = getPersistentCliPath();
+	if (source !== target) {
+		mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
+		writeFileSync(
+			join(dirname(target), "package.json"),
+			'{"type":"module"}\n',
+			{ mode: 0o600 },
+		);
+		const temporary = `${target}.${randomUUID()}.tmp`;
+		try {
+			copyFileSync(source, temporary);
+			renameSync(temporary, target);
+		} finally {
+			rmSync(temporary, { force: true });
+		}
+	}
+	return [process.execPath, target, ...args];
+}
+
+export function isPersistentHookCommand(
+	command: readonly string[],
+	args: readonly string[],
+): boolean {
+	return (
+		command.length === args.length + 2 &&
+		command[1] === getPersistentCliPath() &&
+		args.every((arg, index) => command[index + 2] === arg)
+	);
+}
+
+export function getPersistentCliPath(): string {
+	return join(getConfigDir(), "runtime", "cli.js");
+}
+
+export function quoteHookArgument(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/apps/cli/src/lib/auto-upload-analytics.ts
+++ b/apps/cli/src/lib/auto-upload-analytics.ts
@@ -1,0 +1,117 @@
+import type { Source } from "../contracts/index.js";
+import type { ProductAnalyticsRepositoryCounts } from "../contracts/product-analytics.js";
+import {
+	CliProductAnalyticsEvents,
+	captureCliProductAnalyticsEvent,
+	getBaseCliEventPayload,
+	getCliDistinctId,
+	normalizeFailureReason,
+	shouldDisableCliPersonProfile,
+} from "./product-analytics.js";
+
+interface RepositoryAnalyticsProject {
+	readonly repositoryKey: string;
+	readonly organizationId: string | undefined;
+	readonly source: Source;
+	readonly sessionIds: readonly string[];
+}
+
+interface AutoUploadRepositorySummary extends ProductAnalyticsRepositoryCounts {
+	readonly organization_id: string | undefined;
+	readonly agent_source: Source;
+}
+
+export type AutoUploadHookResult =
+	| {
+			readonly source: Source;
+			readonly status: "enabled";
+			readonly alreadyInstalled: boolean;
+	  }
+	| {
+			readonly source: Source;
+			readonly status: "failed";
+			readonly error: unknown;
+	  };
+
+export function captureAutoUploadSetupResult(options: {
+	readonly result: AutoUploadHookResult;
+	readonly summaries: readonly AutoUploadRepositorySummary[];
+	readonly userId: string | undefined;
+	readonly command: "enable" | "upload";
+}): void {
+	for (const summary of options.summaries) {
+		if (summary.agent_source !== options.result.source) continue;
+		const common = {
+			distinctId: getCliDistinctId(options.userId),
+			surface: "cli" as const,
+			disablePersonProfile: shouldDisableCliPersonProfile(options.userId),
+		};
+		const payload = {
+			...summary,
+			user_id: options.userId,
+			setup_command: options.command,
+			...getBaseCliEventPayload(),
+		};
+		if (options.result.status === "enabled") {
+			captureCliProductAnalyticsEvent({
+				...common,
+				event: CliProductAnalyticsEvents.AUTO_UPLOAD_ENABLED,
+				payload: {
+					...payload,
+					is_already_enabled: options.result.alreadyInstalled,
+				},
+			});
+		} else {
+			captureCliProductAnalyticsEvent({
+				...common,
+				event: CliProductAnalyticsEvents.AUTO_UPLOAD_ENABLE_FAILED,
+				payload: {
+					...payload,
+					failure_stage: "hook_install",
+					failure_reason: normalizeFailureReason(options.result.error),
+				},
+			});
+		}
+	}
+}
+
+// Keys and session IDs stay local. Only aggregate counts leave this function.
+export function summarizeAutoUploadRepositories(
+	projects: readonly RepositoryAnalyticsProject[],
+): AutoUploadRepositorySummary[] {
+	const scopes = new Map<
+		string | undefined,
+		Map<Source, Map<string, Set<string>>>
+	>();
+	for (const project of projects) {
+		const sources =
+			scopes.get(project.organizationId) ??
+			new Map<Source, Map<string, Set<string>>>();
+		scopes.set(project.organizationId, sources);
+		const repositories =
+			sources.get(project.source) ?? new Map<string, Set<string>>();
+		sources.set(project.source, repositories);
+		const sessions =
+			repositories.get(project.repositoryKey) ?? new Set<string>();
+		repositories.set(project.repositoryKey, sessions);
+		for (const sessionId of project.sessionIds) sessions.add(sessionId);
+	}
+
+	const summaries: AutoUploadRepositorySummary[] = [];
+	for (const [organizationId, sources] of scopes) {
+		for (const [source, repositories] of sources) {
+			const counts = Array.from(
+				repositories.values(),
+				(sessions) => sessions.size,
+			).sort((a, b) => b - a);
+			summaries.push({
+				organization_id: organizationId,
+				agent_source: source,
+				repository_count: counts.length,
+				session_count: counts.reduce((sum, count) => sum + count, 0),
+				repository_session_counts: counts,
+			});
+		}
+	}
+	return summaries;
+}

--- a/apps/cli/src/lib/cli-connection.ts
+++ b/apps/cli/src/lib/cli-connection.ts
@@ -1,0 +1,115 @@
+import { randomBytes } from "node:crypto";
+import {
+	CLI_CONNECTION_PATH,
+	CliConnectionSecretSchema,
+	type CliConnectionSnapshot,
+	CliConnectionSnapshotSchema,
+	type CliConnectionUpdate,
+} from "../contracts/cli-connection.js";
+import type { Credentials } from "./credentials.js";
+
+export async function connectBrowser(apiBase: string, code: string) {
+	CliConnectionSecretSchema.parse(code);
+	const writerToken = randomBytes(32).toString("base64url");
+	const initial = await requestConnection(
+		`${apiBase}${CLI_CONNECTION_PATH}/redeem`,
+		{ code, writerToken },
+	);
+	let sequence = 0;
+	let queue: Promise<unknown> = Promise.resolve();
+	let stopped = false;
+	let heartbeatFailure: unknown;
+
+	function update(
+		update: CliConnectionUpdate["update"],
+		credentials?: Credentials,
+	): Promise<CliConnectionSnapshot> {
+		const pending = queue.then(async () => {
+			if (heartbeatFailure) throw heartbeatFailure;
+			const snapshot = await requestConnection(
+				`${apiBase}${CLI_CONNECTION_PATH}/${initial.id}/update`,
+				{ writerToken, sequence: sequence + 1, update },
+				credentials,
+			);
+			sequence++;
+			return snapshot;
+		});
+		queue = pending.catch(() => {});
+		return pending;
+	}
+	const heartbeat = setInterval(() => {
+		if (!stopped)
+			void update({ kind: "heartbeat" }).catch((error: unknown) => {
+				heartbeatFailure = error;
+			});
+	}, 30_000);
+	heartbeat.unref();
+	return {
+		id: initial.id,
+		browserOrigin: initial.browserOrigin,
+		update,
+		stop() {
+			stopped = true;
+			clearInterval(heartbeat);
+		},
+	};
+}
+
+async function requestConnection(
+	url: string,
+	body: unknown,
+	credentials?: Credentials,
+): Promise<CliConnectionSnapshot> {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+	if (credentials) {
+		if (credentials.authType === "api-key")
+			headers["X-API-Key"] = credentials.token;
+		else headers.Authorization = `Bearer ${credentials.token}`;
+	}
+	for (let attempt = 0; ; attempt++) {
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				method: "POST",
+				headers,
+				body: JSON.stringify(body),
+				signal: AbortSignal.timeout(10_000),
+				redirect: "error",
+			});
+		} catch (error) {
+			if (attempt >= 2)
+				throw new Error(
+					"Could not connect to the demo. Check your connection and copy a fresh command.",
+					{ cause: error },
+				);
+			await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+			continue;
+		}
+		if (response.status >= 500 && attempt < 2) {
+			await response.body?.cancel();
+			await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+			continue;
+		}
+		if (!response.ok) {
+			await response.body?.cancel();
+			if (
+				response.status === 404 ||
+				response.status === 410 ||
+				response.status === 409
+			)
+				throw new Error(
+					"This connection code expired or was already used. Copy a fresh command from the demo.",
+				);
+			if (response.status === 403)
+				throw new Error(
+					"Approve this connection in the same browser where you copied the command.",
+				);
+			throw new Error(
+				`The demo connection failed (${response.status}). Please try again.`,
+			);
+		}
+		return CliConnectionSnapshotSchema.parse(await response.json());
+	}
+}

--- a/apps/cli/src/lib/product-analytics-config.ts
+++ b/apps/cli/src/lib/product-analytics-config.ts
@@ -1,0 +1,66 @@
+import { getDefaultApiBase } from "./api-target.js";
+
+export interface ProductAnalyticsConfig {
+	readonly key: string;
+	readonly host: string;
+}
+
+// Replaced by the release build. Source checkouts stay unconfigured by default.
+declare const OPALINE_BUNDLED_ANALYTICS: ProductAnalyticsConfig | null;
+
+export function getProductAnalyticsConfig(
+	environment: NodeJS.ProcessEnv = process.env,
+	bundled: ProductAnalyticsConfig | null = typeof OPALINE_BUNDLED_ANALYTICS ===
+	"undefined"
+		? null
+		: OPALINE_BUNDLED_ANALYTICS,
+): ProductAnalyticsConfig | null {
+	if (
+		environment.DO_NOT_TRACK === "1" ||
+		environment.POSTHOG_ENABLED?.trim().toLowerCase() === "false"
+	) {
+		return null;
+	}
+	const explicitlyEnabled = environment.POSTHOG_ENABLED === "true";
+	if (!explicitlyEnabled && (!bundled || environment.NODE_ENV === "test")) {
+		return null;
+	}
+	const key = (environment.POSTHOG_KEY ?? bundled?.key ?? "").trim();
+	const host = (environment.POSTHOG_HOST ?? bundled?.host ?? "").trim();
+	if (!key || !host) return null;
+	return { key, host };
+}
+
+export function getProductAnalyticsEnvironment(
+	environment: NodeJS.ProcessEnv = process.env,
+): "production" | "staging" | "development" | "local" {
+	try {
+		const hostname = new URL(getDefaultApiBase(environment)).hostname;
+		if (["localhost", "127.0.0.1", "[::1]"].includes(hostname)) return "local";
+		if (hostname === "opaline.so" || hostname === "app.rudel.ai") {
+			return "production";
+		}
+		if (hostname.split(/[.-]/).includes("staging")) return "staging";
+	} catch {
+		// An invalid API override must not make analytics fail the command.
+	}
+	return "development";
+}
+
+export function getBuildProductAnalyticsConfig(
+	environment: NodeJS.ProcessEnv,
+): ProductAnalyticsConfig | null {
+	const key = environment.OPALINE_BUILD_POSTHOG_KEY?.trim() ?? "";
+	const host = environment.OPALINE_BUILD_POSTHOG_HOST?.trim() ?? "";
+	if (!key && !host) return null;
+	if (!key.startsWith("phc_") || !host) {
+		throw new Error(
+			"CLI analytics builds require a public phc_ project token and an HTTPS ingestion host.",
+		);
+	}
+	const url = new URL(host);
+	if (url.protocol !== "https:" || url.username || url.password) {
+		throw new Error("CLI analytics builds require an HTTPS ingestion host.");
+	}
+	return { key, host: url.href.replace(/\/$/, "") };
+}

--- a/apps/cli/src/lib/product-analytics.ts
+++ b/apps/cli/src/lib/product-analytics.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ORPCError } from "@orpc/client";
 import { PostHog } from "posthog-node";
+import { z } from "zod";
 import pkg from "../../package.json" with { type: "json" };
 import type {
 	ProductAnalyticsEventName,
@@ -14,8 +15,12 @@ import {
 	PRODUCT_ANALYTICS_EVENTS,
 	parseProductAnalyticsEvent,
 } from "../contracts/index.js";
-import { getApiBaseOverride } from "./api-target.js";
+import { debugLog } from "./debug.js";
 import { getConfigDir } from "./local-state.js";
+import {
+	getProductAnalyticsConfig,
+	getProductAnalyticsEnvironment,
+} from "./product-analytics-config.js";
 
 type CliSurface = "cli" | "hook";
 type CliAutoProps = "event_version" | "surface" | "environment";
@@ -27,44 +32,44 @@ type CliCapturePayload<Name extends ProductAnalyticsEventName> = Omit<
 const ANALYTICS_STATE_FILE = "product-analytics.json";
 
 let client: PostHog | null | undefined;
-
-type AnalyticsState = {
-	cli_installation_id?: string;
-	cli_first_run_tracked?: boolean;
-	cli_login_attempt_count?: number;
-};
-
-function isAnalyticsEnabled() {
-	return process.env.POSTHOG_ENABLED === "true";
-}
-
-function getEnvironment(): "production" | "staging" | "development" | "local" {
-	const apiBase = getApiBaseOverride() ?? "";
-	if (apiBase.includes("localhost") || apiBase.includes("127.0.0.1")) {
-		return "local";
-	}
-	if (apiBase.includes("staging")) {
-		return "staging";
-	}
-	if (process.env.NODE_ENV === "production") {
-		return "production";
-	}
-	return "development";
-}
+const ephemeralInstallationId = randomUUID();
+const AnalyticsStateSchema = z.object({
+	cli_installation_id: z.string().min(1).optional(),
+	cli_anonymous_id: z.string().min(1).optional(),
+	cli_identified_user_id: z.string().min(1).optional(),
+	cli_first_run_event_id: z.string().uuid().optional(),
+	cli_first_run_delivered: z.boolean().optional(),
+	cli_login_attempt_count: z.number().int().nonnegative().optional(),
+});
+type AnalyticsState = z.infer<typeof AnalyticsStateSchema>;
+const FlushedEventsSchema = z.array(z.object({ uuid: z.string().optional() }));
 
 function getClient() {
 	if (client !== undefined) {
 		return client;
 	}
 
-	const key = (process.env.POSTHOG_KEY ?? "").trim();
-	const host = (process.env.POSTHOG_HOST ?? "").trim();
-	if (!isAnalyticsEnabled() || key.length === 0 || host.length === 0) {
+	const config = getProductAnalyticsConfig();
+	if (!config) {
 		client = null;
 		return client;
 	}
-
-	client = new PostHog(key, { host });
+	try {
+		client = new PostHog(config.key, {
+			host: config.host,
+			flushAt: 1,
+			flushInterval: 0,
+			requestTimeout: 1_500,
+			fetchRetryCount: 1,
+			fetchRetryDelay: 100,
+			disableGeoip: true,
+		});
+		client.on("flush", recordDeliveredFirstRun);
+		client.on("error", () => debugLog("analytics delivery failed"));
+	} catch {
+		debugLog("analytics initialization failed");
+		client = null;
+	}
 	return client;
 }
 
@@ -73,22 +78,39 @@ function getAnalyticsStatePath() {
 }
 
 function readAnalyticsState(): AnalyticsState {
-	const statePath = getAnalyticsStatePath();
-	if (!existsSync(statePath)) {
-		return {};
-	}
-
 	try {
-		return JSON.parse(readFileSync(statePath, "utf8")) as AnalyticsState;
+		const statePath = getAnalyticsStatePath();
+		if (!existsSync(statePath)) return {};
+		const parsed = AnalyticsStateSchema.safeParse(
+			JSON.parse(readFileSync(statePath, "utf8")),
+		);
+		return parsed.success ? parsed.data : {};
 	} catch {
 		return {};
 	}
 }
 
 function writeAnalyticsState(state: AnalyticsState) {
-	const statePath = getAnalyticsStatePath();
-	mkdirSync(getConfigDir(), { recursive: true, mode: 0o700 });
-	writeFileSync(statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
+	try {
+		const statePath = getAnalyticsStatePath();
+		mkdirSync(getConfigDir(), { recursive: true, mode: 0o700 });
+		writeFileSync(statePath, JSON.stringify(state, null, 2), { mode: 0o600 });
+	} catch {
+		debugLog("analytics state could not be saved");
+	}
+}
+
+function recordDeliveredFirstRun(messages: unknown) {
+	const parsed = FlushedEventsSchema.safeParse(messages);
+	if (!parsed.success) return;
+	debugLog("analytics delivered", { eventCount: parsed.data.length });
+	const state = readAnalyticsState();
+	if (
+		state.cli_first_run_event_id &&
+		parsed.data.some(({ uuid }) => uuid === state.cli_first_run_event_id)
+	) {
+		writeAnalyticsState({ ...state, cli_first_run_delivered: true });
+	}
 }
 
 function buildPayload<Name extends ProductAnalyticsEventName>(
@@ -100,7 +122,7 @@ function buildPayload<Name extends ProductAnalyticsEventName>(
 		...payload,
 		event_version: PRODUCT_ANALYTICS_EVENT_VERSION,
 		surface,
-		environment: getEnvironment(),
+		environment: getProductAnalyticsEnvironment(),
 	});
 }
 
@@ -120,11 +142,12 @@ export function getPlatformOs(): ProductAnalyticsPlatformOs {
 }
 
 export function getOrCreateCliInstallationId() {
+	if (!getProductAnalyticsConfig()) return ephemeralInstallationId;
 	const state = readAnalyticsState();
 	if (typeof state.cli_installation_id === "string") {
 		return state.cli_installation_id;
 	}
-	const cliInstallationId = randomUUID();
+	const cliInstallationId = ephemeralInstallationId;
 	writeAnalyticsState({
 		...state,
 		cli_installation_id: cliInstallationId,
@@ -132,29 +155,40 @@ export function getOrCreateCliInstallationId() {
 	return cliInstallationId;
 }
 
-export function consumeCliFirstRun(
-	cliInstallationId = getOrCreateCliInstallationId(),
-) {
+export function trackCliFirstRun(options: {
+	commandName: ProductAnalyticsEventPayload<"CLI First Run">["command_name"];
+	isAuthenticated: boolean;
+	userId?: string;
+}) {
+	if (!getClient()) return;
+	const cliInstallationId = getOrCreateCliInstallationId();
 	const state = readAnalyticsState();
-	if (state.cli_first_run_tracked) {
-		return {
-			cliInstallationId,
-			shouldTrack: false,
-		} as const;
-	}
-
+	if (state.cli_first_run_delivered) return;
+	// Older releases marked this event before checking whether capture was enabled.
+	// Only the delivery marker is authoritative; retain the UUID when retrying.
+	const eventId = state.cli_first_run_event_id ?? randomUUID();
 	writeAnalyticsState({
 		...state,
 		cli_installation_id: cliInstallationId,
-		cli_first_run_tracked: true,
+		cli_first_run_event_id: eventId,
 	});
-	return {
-		cliInstallationId,
-		shouldTrack: true,
-	} as const;
+	captureCliProductAnalyticsEvent({
+		distinctId: getCliDistinctId(options.userId),
+		event: PRODUCT_ANALYTICS_EVENTS.CLI_FIRST_RUN,
+		surface: "cli",
+		disablePersonProfile: shouldDisableCliPersonProfile(options.userId),
+		eventId,
+		payload: {
+			cli_installation_id: cliInstallationId,
+			command_name: options.commandName,
+			is_authenticated: options.isAuthenticated,
+			...getBaseCliEventPayload(),
+		},
+	});
 }
 
 export function getNextCliLoginAttemptNumber() {
+	if (!getClient()) return 1;
 	const state = readAnalyticsState();
 	const nextAttemptNumber = (state.cli_login_attempt_count ?? 0) + 1;
 	writeAnalyticsState({
@@ -174,6 +208,7 @@ export function captureCliProductAnalyticsEvent<
 	payload: CliCapturePayload<Name>;
 	surface: CliSurface;
 	disablePersonProfile?: boolean;
+	eventId?: string;
 }) {
 	const instance = getClient();
 	if (!instance) {
@@ -189,25 +224,66 @@ export function captureCliProductAnalyticsEvent<
 		instance.capture({
 			distinctId: options.distinctId,
 			event: options.event,
+			uuid: options.eventId,
 			properties: options.disablePersonProfile
 				? { ...payload, $process_person_profile: false }
 				: payload,
 		});
 	} catch {
-		// Analytics must never break CLI execution.
+		debugLog("analytics event rejected", { event: options.event });
 	}
 }
 
-export async function shutdownCliProductAnalytics(timeoutMs = 5_000) {
+export function identifyCliProductAnalyticsUser(userId: string) {
 	const instance = getClient();
+	if (!instance) return;
+	try {
+		let state = readAnalyticsState();
+		if (
+			state.cli_identified_user_id &&
+			state.cli_identified_user_id !== userId
+		) {
+			resetCliProductAnalyticsIdentity();
+			state = readAnalyticsState();
+		}
+		const anonymousId =
+			state.cli_anonymous_id ?? getOrCreateCliInstallationId();
+		instance.identify({
+			distinctId: userId,
+			properties: { $anon_distinct_id: anonymousId },
+		});
+		writeAnalyticsState({
+			...readAnalyticsState(),
+			cli_anonymous_id: anonymousId,
+			cli_identified_user_id: userId,
+		});
+	} catch {
+		debugLog("analytics identity could not be linked");
+	}
+}
+
+export function resetCliProductAnalyticsIdentity() {
+	if (!getProductAnalyticsConfig()) return;
+	writeAnalyticsState({
+		...readAnalyticsState(),
+		cli_anonymous_id: randomUUID(),
+		cli_identified_user_id: undefined,
+	});
+}
+
+export async function shutdownCliProductAnalytics(timeoutMs = 3_500) {
+	const instance = client;
 	if (!instance) {
+		client = undefined;
 		return;
 	}
 
 	try {
 		await instance.shutdown(timeoutMs);
 	} catch {
-		// Ignore shutdown failures.
+		debugLog("analytics shutdown failed");
+	} finally {
+		client = undefined;
 	}
 }
 
@@ -250,16 +326,16 @@ export function normalizeFailureReason(error: unknown) {
 	if (message.includes("forbidden") || message.includes("unauthorized")) {
 		return "auth_error";
 	}
-	return (
-		message
-			.replace(/[^a-z0-9]+/g, "_")
-			.replace(/^_+|_+$/g, "")
-			.slice(0, 64) || "unknown"
-	);
+	// Arbitrary errors can contain paths, repository names, URLs, or credentials.
+	return "unknown";
 }
 
 export function getCliDistinctId(userId?: string | null) {
-	return userId ?? getOrCreateCliInstallationId();
+	if (userId) return userId;
+	if (!getProductAnalyticsConfig()) return ephemeralInstallationId;
+	return (
+		readAnalyticsState().cli_anonymous_id ?? getOrCreateCliInstallationId()
+	);
 }
 
 export function shouldDisableCliPersonProfile(userId?: string | null) {

--- a/apps/cli/src/run-cli.ts
+++ b/apps/cli/src/run-cli.ts
@@ -4,26 +4,37 @@ import { app } from "./app.js";
 import { loadCredentials } from "./lib/credentials.js";
 import { debugLog } from "./lib/debug.js";
 import {
-	CliProductAnalyticsEvents,
-	captureCliProductAnalyticsEvent,
-	consumeCliFirstRun,
-	getBaseCliEventPayload,
 	shutdownCliProductAnalytics,
+	trackCliFirstRun,
 } from "./lib/product-analytics.js";
 import { initializeR2StagingCleanup } from "./lib/r2-staging-cleanup.js";
 
 export async function runCli(
 	args: readonly string[] = process.argv.slice(2),
 ): Promise<void> {
-	const commandName = getTopLevelCommandName(args);
+	const commandArgs =
+		args.length === 0 ||
+		(args[0]?.startsWith("--") &&
+			args.some((arg) => arg === "--code" || arg.startsWith("--code=")))
+			? ["connect", ...args]
+			: args;
+	const commandName = getTopLevelCommandName(commandArgs);
 	debugLog("starting command", { command: commandName, version: pkg.version });
 	await initializeR2StagingCleanup();
-	if (commandName !== "doctor") {
-		trackFirstRun(commandName);
-	}
-
 	try {
-		await run(app, args, { process });
+		if (commandName !== "doctor" && commandName !== "hooks") {
+			try {
+				const credentials = loadCredentials();
+				trackCliFirstRun({
+					commandName,
+					isAuthenticated: credentials !== null,
+					userId: credentials?.user?.id,
+				});
+			} catch {
+				debugLog("analytics startup failed");
+			}
+		}
+		await run(app, commandArgs, { process });
 	} finally {
 		await shutdownCliProductAnalytics();
 		debugLog("command finished", {
@@ -36,6 +47,7 @@ export async function runCli(
 function getTopLevelCommandName(args: readonly string[]) {
 	const commandName = args.find((argument) => !argument.startsWith("-"));
 	switch (commandName) {
+		case "connect":
 		case "login":
 		case "logout":
 		case "whoami":
@@ -50,22 +62,4 @@ function getTopLevelCommandName(args: readonly string[]) {
 		default:
 			return "help";
 	}
-}
-
-function trackFirstRun(commandName: ReturnType<typeof getTopLevelCommandName>) {
-	const { cliInstallationId, shouldTrack } = consumeCliFirstRun();
-	if (!shouldTrack) return;
-
-	captureCliProductAnalyticsEvent({
-		distinctId: cliInstallationId,
-		event: CliProductAnalyticsEvents.CLI_FIRST_RUN,
-		surface: "cli",
-		disablePersonProfile: true,
-		payload: {
-			cli_installation_id: cliInstallationId,
-			command_name: commandName,
-			is_authenticated: loadCredentials() !== null,
-			...getBaseCliEventPayload(),
-		},
-	});
 }

--- a/apps/cli/turbo.json
+++ b/apps/cli/turbo.json
@@ -1,8 +1,12 @@
 {
 	"extends": ["//"],
 	"tasks": {
+		"build": {
+			"env": ["OPALINE_BUILD_POSTHOG_KEY", "OPALINE_BUILD_POSTHOG_HOST"]
+		},
 		"dev": {
 			"passThroughEnv": [
+				"DO_NOT_TRACK",
 				"NODE_ENV",
 				"OPALINE_ALLOW_INSECURE_API_BASE",
 				"OPALINE_ALLOW_INSECURE_ENDPOINT",
@@ -20,6 +24,7 @@
 		},
 		"test": {
 			"passThroughEnv": [
+				"DO_NOT_TRACK",
 				"OPALINE_CONFIG_DIR",
 				"OPALINE_LOG_LEVEL",
 				"OPALINE_PACKED_CLI",
@@ -28,6 +33,7 @@
 		},
 		"test:integration": {
 			"passThroughEnv": [
+				"DO_NOT_TRACK",
 				"OPALINE_CONFIG_DIR",
 				"OPALINE_LOG_LEVEL",
 				"RUDEL_CONFIG_DIR"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"engines": {
 		"node": ">=20"
 	},
-	"packageManager": "bun@1.3.9",
+	"packageManager": "bun@1.3.10",
 	"workspaces": [
 		"apps/*",
 		"packages/*"


### PR DESCRIPTION
Running `npx @opalinehq/cli@latest` now scans Claude Code and Codex sessions from any directory, shows repository/session counts, and asks which repos to upload and keep syncing before opening login. Commands copied from the demo include a one-time `--code`; selection, disabled repos and upload results are sent to the paired browser. Device approval stays on the originating browser site.

Retain a self-contained Node CLI bundle for automatic hooks so they survive an `npx` cache cleanup. Upgrade existing managed hooks and preserve unrelated configuration. Turning every repo off saves the choice without login.

Repair published PostHog configuration, retry first-run delivery, and track the six existing event types only. Setup results include selected repo count, total sessions and anonymous per-repo session counts; no paths, repo names, codes or content are tracked. Existing opt-outs remain supported.

Validation: full `bun run verify` (702 tests), retained-hook execution after runner-cache removal, and a browser + real PostgreSQL/ClickHouse flow covering copy, pre-login discovery, selection push, device approval, upload, dashboard rows and Claude/Codex automatic uploads. All-off settings and browser display also verified.

Requires the backend CLI-connection endpoint before publication. Per-session browser progress and streaming dashboard rows remain deferred.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opalinehq/codesmith/cli/pr/475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791829247&installation_model_id=433970&pr_number=475&repository=opalinehq%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fopalinehq%2Fcli%2Fpull%2F475&signature=077ba338c8f884a74ae6971a403093e9615387ba97730d862581b49bc18df899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->